### PR TITLE
Added dark mode to the frontend

### DIFF
--- a/flask_logging_server/static/dark_mode.css
+++ b/flask_logging_server/static/dark_mode.css
@@ -1,0 +1,60 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+}
+
+.dark-mode {
+    --bg-color: #121212;
+    --text-color: #ffffff;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: Arial, sans-serif;
+    transition: background 0.3s, color 0.3s;
+    text-align: center;
+    padding: 20px;
+}
+
+.toggle-btn {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    padding: 10px;
+    border-radius: 5px;
+    background: #333;
+    color: white;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background 0.3s;
+}
+
+/* Default table styling */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: white;
+    color: rgb(0, 0, 0);
+    transition: background 0.3s, color 0.3s;
+}
+
+th, td {
+    border: 1px solid black;
+    padding: 10px;
+    text-align: left;
+}
+
+
+
+/* Dark mode table styling */
+.dark-mode table,
+.dark-mode th{
+    background-color: #222;
+    color: white;
+}
+
+.dark-mode th, 
+.dark-mode td{
+    border: 1px solid white;
+}

--- a/flask_logging_server/static/dark_mode.js
+++ b/flask_logging_server/static/dark_mode.js
@@ -1,0 +1,18 @@
+function toggleDarkMode() {
+    console.log("dark");
+    document.body.classList.toggle("dark-mode");
+
+    // Save user preference in localStorage
+    if (document.body.classList.contains("dark-mode")) {
+        localStorage.setItem("theme", "dark");
+    } else {
+        localStorage.setItem("theme", "light");
+    }
+}
+
+// Load user preference on page load
+window.onload = () => {
+    if (localStorage.getItem("theme") === "dark") {
+        document.body.classList.add("dark-mode");
+    }
+};

--- a/flask_logging_server/static/styles.css
+++ b/flask_logging_server/static/styles.css
@@ -67,10 +67,6 @@ th {
     background-color: #f4f4f4;
 }
 
-tbody tr:nth-child(even) {
-    background-color: #f9f9f9;
-}
-
 header {
     background-color: #000000;
     padding: 20px;

--- a/flask_logging_server/templates/logs.html
+++ b/flask_logging_server/templates/logs.html
@@ -5,14 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Server Logs</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link rel="stylesheet" href="../static/dark_mode.css">
 </head>
 <body>
     <div class="container">
+        <button class="toggle-btn" onclick="toggleDarkMode()">Toggle Dark Mode</button>
         <h1>Server Logs</h1>
         <pre id="logs">
             <!-- Logs will be dynamically updated here -->
         </pre>
     </div>
     <script src="{{ url_for('static', filename='all_logs.js') }}"></script>
+    <script src="../static/dark_mode.js"></script>
 </body>
 </html>

--- a/flask_logging_server/templates/simplified_logs.html
+++ b/flask_logging_server/templates/simplified_logs.html
@@ -3,8 +3,10 @@
 <head>
     <title>Simplified Logs</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles.css') }}">
+    <link rel="stylesheet" href="../static/dark_mode.css">
 </head>
 <body>
+    <button class="toggle-btn" onclick="toggleDarkMode()">Toggle Dark Mode</button>
     <h1>Simplified Logs</h1>
     <div id="logs-container">
         <table id="logs-table">
@@ -29,5 +31,6 @@
         </table>
     </div>
     <script src="{{ url_for('static', filename='logs.js') }}"></script>
+    <script src="../static/dark_mode.js"></script>
 </body>
 </html>


### PR DESCRIPTION
solved #3 

# Changes
- A dark mode toggle button was added to the frontend.
- Users can easily toggle b/w light mode and dark mode.
- The preferences are stored in the `localstorage`

# Images
![image](https://github.com/user-attachments/assets/0bc78fd5-07b2-4a99-b2d1-d51ee847d7a2)
