### PR TITLE
Add enhanced footer with GitHub and documentation links

### DIFF
--- a/flask_logging_server/static/styles.css
+++ b/flask_logging_server/static/styles.css
@@ -112,11 +112,41 @@ nav ul li a:hover {
 
 footer {
     background-color: #000000;
-    padding: 10px;
+    padding: 20px;
     color: white;
     margin-top: 20px;
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    position: relative;
+    z-index: 1;
+    width: 100%;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.footer-links {
+    display: flex;
+    gap: 20px;
+}
+
+.footer-links a {
+    color: white;
+    text-decoration: none;
+    transition: opacity 0.3s ease;
+}
+
+.footer-links a:hover {
+    opacity: 0.8;
+}
+
+.footer-version {
+    color: #ffffff80;
 }
 
 @media (max-width: 768px) {

--- a/flask_logging_server/templates/landing.html
+++ b/flask_logging_server/templates/landing.html
@@ -35,7 +35,14 @@
             </ul>
         </nav>
         <footer>
-            <p>&copy; 2024 DICOMHawk. All rights reserved.</p>
+            <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 20px;">
+                <p>&copy; 2024 DICOMHawk. All rights reserved.</p>
+                <div style="display: flex; gap: 20px;">
+                    <a href="https://github.com/honeynet/DICOMHawk" style="color: white; text-decoration: none;" target="_blank">GitHub</a>
+                    <a href="https://github.com/honeynet/DICOMHawk#readme" style="color: white; text-decoration: none;" target="_blank">Documentation</a>
+                    <span>v1.0.0</span>
+                </div>
+            </div>
         </footer>
     </div>
     <script>

--- a/flask_logging_server/templates/landing.html
+++ b/flask_logging_server/templates/landing.html
@@ -35,12 +35,12 @@
             </ul>
         </nav>
         <footer>
-            <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 20px;">
+            <div class="footer-content">
                 <p>&copy; 2024 DICOMHawk. All rights reserved.</p>
-                <div style="display: flex; gap: 20px;">
-                    <a href="https://github.com/honeynet/DICOMHawk" style="color: white; text-decoration: none;" target="_blank">GitHub</a>
-                    <a href="https://github.com/honeynet/DICOMHawk#readme" style="color: white; text-decoration: none;" target="_blank">Documentation</a>
-                    <span>v1.0.0</span>
+                <div class="footer-links">
+                    <a href="https://github.com/honeynet/DICOMHawk" target="_blank">GitHub</a>
+                    <a href="https://github.com/honeynet/DICOMHawk#readme" target="_blank">Documentation</a>
+                    <span class="footer-version">v1.0.0</span>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
# Enhanced Footer Implementation

## Changes Made
- Added GitHub repository link to footer
- Added documentation link pointing to README
- Included version display
- Maintained existing copyright notice
- Implemented responsive flex layout

## Implementation Details
- Updated landing.html with new footer structure
- Added external links with target="_blank"
- Maintained existing theme and styling
- Ensured mobile responsiveness

## Testing Done
- Verified all links work correctly
- Tested responsive layout on multiple devices
- Checked external links open in new tabs
- Validated copyright notice display

## Screenshots
![Screenshot 2025-02-22 044708](https://github.com/user-attachments/assets/6cbfb2bc-f61d-450a-888b-37c0dee45210)


Fixes #17 