### PR TITLE
Implement Custom Error Response Pages

### DIFF
--- a/flask_logging_server/__init__.py
+++ b/flask_logging_server/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the flask_logging_server directory a Python package

--- a/flask_logging_server/custom_error_routes.py
+++ b/flask_logging_server/custom_error_routes.py
@@ -1,0 +1,81 @@
+from flask import render_template, request, jsonify, Blueprint
+import uuid
+import datetime
+import json
+from flask_logging_server import error_config 
+
+error_routes = Blueprint('error_routes', __name__)
+
+@error_routes.route('/log_error_page_interaction', methods=['POST'])
+def log_interaction():
+    try:
+        data = request.json
+        error_code = data.get('error_code', 'unknown')
+        request_id = data.get('request_id', 'unknown')
+        time_spent = data.get('time_spent', 0)
+        
+        client_ip = request.remote_addr
+        success = error_config.log_error_page_interaction(
+            error_code, request_id, client_ip, time_spent
+        )
+        
+        print(f"Received error page interaction: Error={error_code}, Request={request_id}, Time={time_spent}s")
+        
+        return jsonify({"success": success}), 200
+    except Exception as e:
+        print(f"Error logging interaction: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+    
+@error_routes.route('/trigger-error/<int:error_code>')
+def trigger_error(error_code):
+    
+    print(f"Triggering error with code: {error_code}")
+    
+    allowed_codes = [400, 401, 403, 404, 500, 503]
+    
+    if error_code in allowed_codes:
+        from flask import abort
+        abort(error_code)
+    else:
+        return f"Error code {error_code} is not supported for testing. Supported codes: {', '.join(map(str, allowed_codes))}"
+
+def register_error_handlers(app):
+    print("Registering custom error handlers...")
+    
+    @app.errorhandler(400)
+    def bad_request_error(error):
+        print("Handling 400 error with custom error page")
+        config = error_config.get_error_config(request, 400)
+        return render_template('custom_error.html', **config), 400
+
+    @app.errorhandler(401)
+    def unauthorized_error(error):
+        print("Handling 401 error with custom error page")
+        config = error_config.get_error_config(request, 401)
+        return render_template('custom_error.html', **config), 401
+
+    @app.errorhandler(403)
+    def forbidden_error(error):
+        print("Handling 403 error with custom error page")
+        config = error_config.get_error_config(request, 403)
+        return render_template('custom_error.html', **config), 403
+
+    @app.errorhandler(404)
+    def not_found_error(error):
+        print("Handling 404 error with custom error page")
+        config = error_config.get_error_config(request, 404)
+        return render_template('custom_error.html', **config), 404
+
+    @app.errorhandler(500)
+    def internal_server_error(error):
+        print("Handling 500 error with custom error page")
+        config = error_config.get_error_config(request, 500)
+        return render_template('custom_error.html', **config), 500
+
+    @app.errorhandler(503)
+    def service_unavailable_error(error):
+        print("Handling 503 error with custom error page")
+        config = error_config.get_error_config(request, 503)
+        return render_template('custom_error.html', **config), 503
+    
+    print("All custom error handlers registered successfully")

--- a/flask_logging_server/error_config.py
+++ b/flask_logging_server/error_config.py
@@ -1,0 +1,110 @@
+import random
+import string
+import datetime
+import socket
+import os
+import uuid
+
+def generate_id(length=8):
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+def random_recent_timestamp():
+    now = datetime.datetime.now()
+    hours_ago = random.randint(1, 24)
+    timestamp = now - datetime.timedelta(hours=hours_ago, minutes=random.randint(0, 59))
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+def get_base_config(request, error_code):
+    request_id = f"REQ-{generate_id(12)}"
+    
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    
+    client_ip = request.remote_addr if request else "127.0.0.1"
+    
+    path = request.path if request else "/unknown"
+    method = request.method if request else "GET"
+    
+    error_reference = f"ERR-{generate_id(16)}"
+    
+    server_version = "3.2.1"
+    
+    environment = random.choice(["PRODUCTION", "STAGING", "DEVELOPMENT"])
+    
+    db_status = random.choice(["CONNECTED", "DEGRADED", "RECONNECTING"])
+    
+    last_check = random_recent_timestamp()
+    
+    config_path = f"/etc/dicom/conf/dicom_server_{random.choice(['prod', 'stage', 'dev'])}.conf"
+    
+    modules = ["core", "storage", "query", "network", "security", "audit"]
+    active_modules = ", ".join(random.sample(modules, random.randint(3, len(modules))))
+    
+    system_user = random.choice(["dicom_service", "pacs_admin", "medical_sys", "radiology_svc"])
+    
+    log_location = f"/var/log/dicom/{random.choice(['error', 'access', 'system', 'security'])}.log"
+    
+    return {
+        "error_code": error_code,
+        "request_id": request_id,
+        "timestamp": timestamp,
+        "client_ip": client_ip,
+        "path": path,
+        "method": method,
+        "error_reference": error_reference,
+        "server_version": server_version,
+        "environment": environment,
+        "db_status": db_status,
+        "last_check": last_check,
+        "config_path": config_path,
+        "active_modules": active_modules,
+        "system_user": system_user,
+        "log_location": log_location
+    }
+
+ERROR_CONFIGS = {
+    400: {
+        "error_title": "Bad Request",
+        "error_message": "The server could not understand the request due to invalid syntax or malformed parameters."
+    },
+    401: {
+        "error_title": "Unauthorized",
+        "error_message": "Authentication is required to access this resource. Please check your credentials and try again."
+    },
+    403: {
+        "error_title": "Forbidden",
+        "error_message": "You do not have permission to access this resource. Access control validation failed."
+    },
+    404: {
+        "error_title": "Not Found",
+        "error_message": "The requested resource could not be found on this server. Please check the URL and try again."
+    },
+    500: {
+        "error_title": "Internal Server Error",
+        "error_message": "The server encountered an unexpected condition that prevented it from fulfilling the request."
+    },
+    503: {
+        "error_title": "Service Unavailable",
+        "error_message": "The server is currently unable to handle the request due to temporary overloading or maintenance."
+    }
+}
+
+def get_error_config(request, error_code):
+    base_config = get_base_config(request, error_code)
+    
+    if error_code in ERROR_CONFIGS:
+        specific_config = ERROR_CONFIGS[error_code]
+    else:
+        specific_config = {
+            "error_title": "Unknown Error",
+            "error_message": f"An unknown error with code {error_code} occurred."
+        }
+    
+    return {**base_config, **specific_config}
+
+def log_error_page_interaction(error_code, request_id, client_ip, time_spent):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    log_entry = f"[{timestamp}] Error page interaction: Code={error_code}, Request={request_id}, IP={client_ip}, Time spent={time_spent}s"
+    
+    print(f"Logging error page interaction: {log_entry}")
+    
+    return True

--- a/flask_logging_server/logserver.py
+++ b/flask_logging_server/logserver.py
@@ -1,17 +1,41 @@
-from flask import Flask, jsonify, render_template, send_from_directory
-import os, json, logging
-
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from flask import Flask, jsonify, render_template, send_from_directory, request, abort
+import os, json
+from datetime import datetime
 logger = logging.getLogger("log_app_logger")
 
 
-Docker_ENV = os.getenv("Docker_ENV", "false")
+Docker_ENV = os.getenv("Docker_ENV", "false").lower()
+print(f"Docker_ENV: {Docker_ENV}")
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+template_dir = os.path.join(current_dir, 'templates')
+static_dir = os.path.join(current_dir, 'static')
+
+print(f"Current directory: {current_dir}")
+print(f"Template directory: {template_dir}")
+print(f"Template directory exists? {os.path.exists(template_dir)}")
+
+if Docker_ENV == "true":
+    log_directory = '/app/logs/'
+    simplified_log_directory = '/app/simplified_logs/'
+    host = "172.29.0.5"
+else:
+    base_dir = os.path.dirname(current_dir)
+    log_directory = os.path.join(base_dir, 'logs')
+    simplified_log_directory = os.path.join(base_dir, 'simplified_logs')
+    host = "0.0.0.0"
+
+print(f"Log directory: {log_directory}")
+print(f"Simplified log directory: {simplified_log_directory}")
 
 
-log_directory, simplified_log_directory, host = (
-    ("/app/logs", "/app/logs", "172.29.0.5")
-    if Docker_ENV == "True"
-    else ("./logs", "./logs", "0.0.0.0")
-)
+os.makedirs(log_directory, exist_ok=True)
+os.makedirs(simplified_log_directory, exist_ok=True)
+os.makedirs(os.path.join(log_directory, "pynetdicom"), exist_ok=True)
+os.makedirs(os.path.join(simplified_log_directory, "simplified"), exist_ok=True)
+os.makedirs(os.path.join(log_directory, "exceptions"), exist_ok=True)
 
 
 # Set logging files
@@ -22,8 +46,46 @@ simplified_log_file_path = os.path.join(
 )
 exception_log_file_path = os.path.join(log_directory, "exceptions/exceptions.log")
 
+print(f"Log file path: {log_file_path}")
+print(f"Simplified log file path: {simplified_log_file_path}")
+print(f"Exception log file path: {exception_log_file_path}")
 
-app = Flask(__name__)
+def setup_logger(name, log_file, level=logging.INFO, when="midnight", interval=1):
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
+    handler = TimedRotatingFileHandler(log_file, when=when, interval=interval)
+    handler.suffix = "%Y%m%d"
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.addHandler(handler)
+    logger.addHandler(logging.StreamHandler())
+    return logger
+
+detailed_logger = setup_logger('detailed_logger', log_file_path, logging.DEBUG)
+simplified_logger = setup_logger('simplified_logger', simplified_log_file_path)
+exception_logger = setup_logger('exception_logger', exception_log_file_path, logging.ERROR)
+
+pynetdicom_logger = logging.getLogger('pynetdicom')
+pynetdicom_logger.setLevel(logging.DEBUG)
+pynetdicom_logger.addHandler(logging.FileHandler(log_file_path))
+
+from flask_logging_server import error_config
+
+def get_server_status():
+    try:
+        return {
+            "status": "running",
+            "last_updated": datetime.now().isoformat()
+        }
+    except Exception as e:
+        exception_logger.error(f"Error getting server status: {e}")
+        return {
+            "status": "error",
+            "last_updated": None,
+            "error": str(e)
+        }
+        
+app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
 
 
 @app.route("/")
@@ -92,16 +154,104 @@ def favicon():
     return send_from_directory("static", "favicon.ico")
 
 
+@app.route('/log_error_page_interaction', methods=['POST'])
+def log_interaction():
+    try:
+        data = request.json
+        error_code = data.get('error_code', 'unknown')
+        request_id = data.get('request_id', 'unknown')
+        time_spent = data.get('time_spent', 0)
+        
+        client_ip = request.remote_addr
+        success = error_config.log_error_page_interaction(
+            error_code, request_id, client_ip, time_spent
+        )
+        
+        print(f"Received error page interaction: Error={error_code}, Request={request_id}, Time={time_spent}s")
+        
+        return jsonify({"success": success}), 200
+    except Exception as e:
+        print(f"Error logging interaction: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/trigger-error/<int:error_code>')
+def trigger_error(error_code):
+    print(f"Triggering error with code: {error_code}")
+    
+    allowed_codes = [400, 401, 403, 404, 500, 503]
+    
+    if error_code in allowed_codes:
+        abort(error_code)
+    else:
+        return f"Error code {error_code} is not supported for testing. Supported codes: {', '.join(map(str, allowed_codes))}"
+
+@app.route('/test-template')
+def test_template():
+    """A route to test if the custom_error template can be rendered"""
+    config = error_config.get_error_config(request, 404)
+    return render_template('custom_error.html', **config)
+
 @app.errorhandler(404)
-def not_found(e):
-    # Do not log 404 errors
-    return jsonify({"error": "Not Found"}), 404
+def not_found_error(error):
+    print("Handling 404 error with custom error page")
+    config = error_config.get_error_config(request, 404)
+    try:
+        return render_template('custom_error.html', **config), 404
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Not Found", "template_error": str(e)}), 404
+
+@app.errorhandler(500)
+def internal_server_error(error):
+    print("Handling 500 error with custom error page")
+    config = error_config.get_error_config(request, 500)
+    try:
+        return render_template('custom_error.html', **config), 500
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Internal Server Error", "template_error": str(e)}), 500
+
+@app.errorhandler(403)
+def forbidden_error(error):
+    print("Handling 403 error with custom error page")
+    config = error_config.get_error_config(request, 403)
+    try:
+        return render_template('custom_error.html', **config), 403
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Forbidden", "template_error": str(e)}), 403
+
+@app.errorhandler(400)
+def bad_request_error(error):
+    print("Handling 400 error with custom error page")
+    config = error_config.get_error_config(request, 400)
+    try:
+        return render_template('custom_error.html', **config), 400
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Bad Request", "template_error": str(e)}), 400
+
+@app.errorhandler(401)
+def unauthorized_error(error):
+    print("Handling 401 error with custom error page")
+    config = error_config.get_error_config(request, 401)
+    try:
+        return render_template('custom_error.html', **config), 401
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Unauthorized", "template_error": str(e)}), 401
+
+@app.errorhandler(503)
+def service_unavailable_error(error):
+    print("Handling 503 error with custom error page")
+    config = error_config.get_error_config(request, 503)
+    try:
+        return render_template('custom_error.html', **config), 503
+    except Exception as e:
+        print(f"Error rendering template: {e}")
+        return jsonify({"error": "Service Unavailable", "template_error": str(e)}), 503
 
 
-@app.errorhandler(Exception)
-def handle_exception(e):
-    return jsonify({"error": "Internal Server Error"}), 500
-
-
-if Docker_ENV != "True":
+if __name__ == '__main__':
+    print("Starting Flask server...")
     app.run(host, debug=True, port=5000)

--- a/flask_logging_server/templates/custom_error.html
+++ b/flask_logging_server/templates/custom_error.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>System Error - {{ error_code }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <style>
+        .error-container {
+            padding: 20px;
+            background-color: white;
+            margin: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        .error-header {
+            color: #d32f2f;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+        .error-details {
+            font-family: monospace;
+            background-color: #f5f5f5;
+            padding: 15px;
+            border-radius: 4px;
+            margin-bottom: 20px;
+            overflow-x: auto;
+        }
+        .system-info {
+            background-color: #fff8e1;
+            border-left: 4px solid #ffc107;
+            padding: 10px;
+            margin-top: 20px;
+        }
+        .sensitive-info {
+            color: #777;
+            font-size: 0.9em;
+        }
+        .error-id {
+            color: #666;
+            font-size: 0.8em;
+            text-align: right;
+            margin-top: 20px;
+        }
+        .nav-bar {
+            background-color: #2c3e50;
+            padding: 10px 20px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+        }
+        .nav-bar a {
+            color: #ecf0f1;
+            text-decoration: none;
+            padding: 8px 15px;
+            margin: 5px;
+            border-radius: 4px;
+            transition: background-color 0.3s, color 0.3s;
+            font-weight: 500;
+        }
+        .nav-bar a:hover {
+            background-color: #3498db;
+            color: white;
+        }
+        .nav-bar a.active {
+            background-color: #2980b9;
+            color: white;
+        }
+        @media (max-width: 768px) {
+            .nav-bar {
+                flex-direction: column;
+                align-items: center;
+            }
+            
+            .nav-bar a {
+                width: 100%;
+                text-align: center;
+                margin: 3px 0;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="nav-bar">
+        <a href="/">Landing Page</a>
+        <a href="/home">Home</a>
+        <a href="/logs">Logs</a>
+        <a href="/logs/simplified_page">Simplified Logs</a>
+        <a href="/status">Server Status</a>
+    </div>
+    
+    <h1>System Error</h1>
+    
+    <div class="error-container">
+        <h2 class="error-header">Error {{ error_code }}: {{ error_title }}</h2>
+        
+        <p>{{ error_message }}</p>
+        
+        <div class="error-details">
+            <p>Request ID: {{ request_id }}</p>
+            <p>Timestamp: {{ timestamp }}</p>
+            <p>Path: {{ path }}</p>
+            <p>Method: {{ method }}</p>
+            <p>Client IP: {{ client_ip }}</p>
+        </div>
+        
+        <div class="system-info">
+            <h3>System Information</h3>
+            <p>Server: DICOM Service v{{ server_version }}</p>
+            <p>Environment: {{ environment }}</p>
+            <p>Database Status: {{ db_status }}</p>
+            <p>Last System Check: {{ last_check }}</p>
+        </div>
+        
+        <div class="sensitive-info">
+            <h3>Debug Information (Internal Use Only)</h3>
+            <p>Configuration Path: {{ config_path }}</p>
+            <p>Active Modules: {{ active_modules }}</p>
+            <p>System User: {{ system_user }}</p>
+            <p>Log Location: {{ log_location }}</p>
+        </div>
+        
+        <p class="error-id">Error Reference: {{ error_reference }}</p>
+    </div>
+    
+    <script>
+        console.log("Custom error page loaded for error code: {{ error_code }}");
+        console.log("Error details:", {
+            code: "{{ error_code }}",
+            title: "{{ error_title }}",
+            message: "{{ error_message }}",
+            requestId: "{{ request_id }}",
+            path: "{{ path }}",
+            clientIp: "{{ client_ip }}"
+        });
+        
+        const startTime = new Date();
+        window.addEventListener('beforeunload', function() {
+            const endTime = new Date();
+            const timeSpent = (endTime - startTime) / 1000; // in seconds
+            
+            fetch('/log_error_page_interaction', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    error_code: "{{ error_code }}",
+                    request_id: "{{ request_id }}",
+                    time_spent: timeSpent
+                }),
+                keepalive: true
+            }).then(response => {
+                console.log("Interaction logged successfully");
+            }).catch(error => {
+                console.error("Failed to log interaction:", error);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Description
This PR implements customizable error pages that appear to contain sensitive system information to keep attackers engaged longer. The error pages serve as honeytokens, encouraging attackers to spend more time investigating, which allows for better intelligence gathering about their techniques and intentions.

### Changes Made

Created a modular error handling system with the following components:
- custom_error_routes.py: Blueprint for error-related routes and error handler registration
- error_config.py: Configuration and data generation for error pages
- templates/custom_error.html: Template for error pages with fake sensitive information
- Added _init_.py to properly expose the error handling functionality
- Modified logserver.py to use the new error handling system

**Added features to make error pages appear to contain sensitive information:**

- Server version and environment details
- Database connection status
- Configuration file paths
- System user information
- Active modules
- Log file locations
- Unique request and error reference IDs

**How to Test**
Start the Flask logging server:

`python -m flask_logging_server.logserver`


### Screenshots

- http://localhost:5000/trigger-error/400
 
![Screenshot 2025-04-22 103923](https://github.com/user-attachments/assets/32a905a3-1879-4df9-bf98-5d4d10a46ccd)

- http://localhost:5000/trigger-error/401
![Screenshot 2025-04-22 103941](https://github.com/user-attachments/assets/20d43630-40ac-4732-857c-0aa1ac66016f)

- http://localhost:5000/trigger-error/403
![Screenshot 2025-04-22 103954](https://github.com/user-attachments/assets/f0a8eb8e-3eb3-45af-af28-086f6457837a)

- http://localhost:5000/trigger-error/404
![Screenshot 2025-04-22 104005](https://github.com/user-attachments/assets/62c31e96-9922-480e-b2fc-9f0854bd6966)

- http://localhost:5000/trigger-error/500
![Screenshot 2025-04-22 104015](https://github.com/user-attachments/assets/ff8a3b32-b3cf-4ac8-b425-a633b0a67935)

- http://localhost:5000/trigger-error/503
![Screenshot 2025-04-22 104025](https://github.com/user-attachments/assets/5bb9e9ec-4585-45a1-83da-bf43c8d796b2)

**Related Issue**
Closes #42  - Custom Error Response Pages
@gtheodoridis 