### PR TITLE
docs: add macOS setup and port 5000 conflict workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ services:
       - VIRUS_TOTAL_API_KEY=APIKEY
 ```
 
+### macOS Users
+
+macOS Control Center binds to TCP port 5000 which prevents the logserver
+from starting.
+
+See docs/macos-setup.md for the workaround.
+
 ## Key Configurable Parameters in `config.py`
 
 The main configurable parameters available in the `config.py` file, along with their possible values are:

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -1,0 +1,47 @@
+# macOS Setup & Troubleshooting
+
+## Prerequisites
+
+- macOS 12+
+- Docker Desktop for Mac
+  https://www.docker.com/products/docker-desktop/
+
+Verify Docker:
+
+docker --version
+docker compose version
+
+---
+
+## Error: zsh: command not found: docker
+
+Install Docker Desktop and ensure the whale icon shows “Docker is running”.
+
+---
+
+## Error: bind 0.0.0.0:5000: address already in use
+
+On macOS, the system Control Center automatically binds to TCP port 5000
+and restarts when killed. This prevents DICOMHawk logserver from starting.
+
+### Fix
+
+Edit `docker-compose.yml`:
+
+Change:
+
+"5000:5000"
+
+to:
+
+"5500:5000"
+
+Then restart:
+
+docker compose down
+docker compose up -d
+
+Access logserver at:
+
+http://localhost:5500
+


### PR DESCRIPTION
macOS Control Center automatically binds to TCP 5000, preventing logserver from starting.
This PR documents the issue and provides a working workaround by remapping the host port.