### PR TITLE
Log rejected DICOM association attempts to Redis (#68)

### DIFF
--- a/dicom_server/core/dicom_handlers.py
+++ b/dicom_server/core/dicom_handlers.py
@@ -28,7 +28,6 @@ class DICOMHandlers:
 
     def handle_assoc(self, event):
         try:
-
             version_name = (
                 str(event.assoc.requestor.implementation_version_name)
                 if event.assoc.requestor.implementation_version_name
@@ -36,6 +35,18 @@ class DICOMHandlers:
             )
             ip = str(event.assoc.requestor.address)
             port = event.assoc.requestor.port
+            assoc = event.assoc
+            calling_ae = assoc.requestor.ae_title.strip()
+            called_ae  = assoc.requestor.requested_ae_title.strip()
+            ip_addr    = assoc.requestor.address
+
+            try:
+                self.event_collector.record_rejected_assoc(
+                ip_addr, calling_ae, called_ae, "ASSOC_ATTEMPT"
+                )
+            except Exception:
+                pass
+
             self.event_collector.session_started(ip, port, version_name)
         except Exception as e:
             self.exceptions_logger.exception(
@@ -311,3 +322,4 @@ class DICOMHandlers:
                 ]
 
         return matching
+

--- a/dicom_server/core/dicom_handlers.py
+++ b/dicom_server/core/dicom_handlers.py
@@ -28,27 +28,46 @@ class DICOMHandlers:
 
     def handle_assoc(self, event):
         try:
-            version_name = (
-                str(event.assoc.requestor.implementation_version_name)
-                if event.assoc.requestor.implementation_version_name
-                else "N/A"
-            )
-            ip = str(event.assoc.requestor.address)
-            port = event.assoc.requestor.port
             assoc = event.assoc
             calling_ae = assoc.requestor.ae_title.strip()
             called_ae  = assoc.requestor.requested_ae_title.strip()
             ip_addr    = assoc.requestor.address
 
-            try:
-                self.event_collector.record_rejected_assoc(
-                ip_addr, calling_ae, called_ae, "ASSOC_ATTEMPT"
-                )
-            except Exception:
-                pass
+            # CALLED AE validation
+            if called_ae not in ALLOWED_AE_TITLES:
+                try:
+                    self.event_collector.record_rejected_assoc(
+                        ip_addr, calling_ae, called_ae, "INVALID_CALLED_AE"
+                    )    
+                except Exception:
+                    pass
 
+                assoc.reject(result=0x01, source=0x01, reason=0x07)
+                return
+
+            # CALLING AE validation
+            if calling_ae not in ALLOWED_AE_TITLES:
+                try:
+                    self.event_collector.record_rejected_assoc(
+                        ip_addr, calling_ae, called_ae, "INVALID_CALLING_AE"
+                    )
+                except Exception:
+                    pass
+
+                assoc.reject(result=0x01, source=0x01, reason=0x03)
+                return
+
+            # Only valid associations reach here
+            version_name = (
+                str(assoc.requestor.implementation_version_name)
+                if assoc.requestor.implementation_version_name
+                else "N/A"
+            )
+            ip = str(ip_addr)
+            port = assoc.requestor.port
             self.event_collector.session_started(ip, port, version_name)
-        except Exception as e:
+
+        except Exception:
             self.exceptions_logger.exception(
                 "Unexpected error while handling association"
             )
@@ -322,4 +341,5 @@ class DICOMHandlers:
                 ]
 
         return matching
+
 

--- a/dicom_server/core/dicom_session_manager.py
+++ b/dicom_server/core/dicom_session_manager.py
@@ -9,8 +9,13 @@ from enums.dicom_session_keys import Sessionkeys as sk
 
 
 class SessionCollector(ISessionCollector):
-    
-    def record_rejected_assoc(self, ip, calling_ae, called_ae, reason):
+    @inject
+    def record_rejected_assoc(self, ip, calling_ae, called_ae, reason,
+                              redis: IRedisService = None):
+
+        if not redis:
+            return
+
         event = {
             "event": "assoc_rejected",
             "timestamp": datetime.utcnow().isoformat(),
@@ -19,7 +24,9 @@ class SessionCollector(ISessionCollector):
             "called_ae": called_ae.decode(errors="ignore"),
             "reason": reason,
         }
-        self.redis_client.add_security_event(event)
+
+        redis.add_security_event(event)
+
 
     @inject
     def __init__(
@@ -188,4 +195,5 @@ class SessionCollector(ISessionCollector):
 
     def set_session_id(self, s_id):
         self.session_info[sk.SESSION_ID.key] = s_id
+
 

--- a/dicom_server/core/dicom_session_manager.py
+++ b/dicom_server/core/dicom_session_manager.py
@@ -9,6 +9,18 @@ from enums.dicom_session_keys import Sessionkeys as sk
 
 
 class SessionCollector(ISessionCollector):
+    
+    def record_rejected_assoc(self, ip, calling_ae, called_ae, reason):
+        event = {
+            "event": "assoc_rejected",
+            "timestamp": datetime.utcnow().isoformat(),
+            "ip": ip,
+            "calling_ae": calling_ae.decode(errors="ignore"),
+            "called_ae": called_ae.decode(errors="ignore"),
+            "reason": reason,
+        }
+        self.redis_client.add_security_event(event)
+
     @inject
     def __init__(
         self,
@@ -176,3 +188,4 @@ class SessionCollector(ISessionCollector):
 
     def set_session_id(self, s_id):
         self.session_info[sk.SESSION_ID.key] = s_id
+

--- a/dicom_server/core/dicom_session_manager.py
+++ b/dicom_server/core/dicom_session_manager.py
@@ -15,18 +15,17 @@ class SessionCollector(ISessionCollector):
 
         if not redis:
             return
-
-        event = {
-            "event": "assoc_rejected",
-            "timestamp": datetime.utcnow().isoformat(),
-            "ip": ip,
-            "calling_ae": calling_ae.decode(errors="ignore"),
-            "called_ae": called_ae.decode(errors="ignore"),
-            "reason": reason,
-        }
-
-        redis.add_security_event(event)
-
+        try:
+            event = {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "ip": str(ip),
+                    "calling_ae": calling_ae.decode(errors="ignore") if isinstance(calling_ae, bytes) else str(calling_ae),
+                    "called_ae": called_ae.decode(errors="ignore") if isinstance(called_ae, bytes) else str(called_ae),
+                    "reason": reason,
+                }
+                redis.add_security_event(event)
+        except Exception:
+            self.exceptions_logger.exception("Failed to record rejected association to Redis")
 
     @inject
     def __init__(
@@ -195,5 +194,6 @@ class SessionCollector(ISessionCollector):
 
     def set_session_id(self, s_id):
         self.session_info[sk.SESSION_ID.key] = s_id
+
 
 

--- a/dicom_server/core/redis_handler.py
+++ b/dicom_server/core/redis_handler.py
@@ -3,6 +3,11 @@ from services.redis_service import IRedisService
 
 
 class RedisClient(IRedisService):
+    def add_security_event(self, event):
+        key = "dicom:events:assoc_rejected"
+        payload = json.dumps(event)
+        self.redis_client.rpush(key, payload)
+        self.redis_client.ltrim(key, -10000, -1)
 
     def __init__(self, app_logger, exceptions_logger, redis_client):
 
@@ -88,3 +93,4 @@ class RedisClient(IRedisService):
             self.exceptions_logger.exception(
                 "Unexpected error while adding integrity check identifier"
             )
+

--- a/dicom_server/services/dicom_session_service.py
+++ b/dicom_server/services/dicom_session_service.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 class ISessionCollector(ABC):
 
     @abstractmethod
+    def record_rejected_assoc(self, ip, calling_ae, called_ae, reason):
+        pass
+
+    @abstractmethod
     def session_started(self, ip, port, version_name) -> None:
         """Start the DICOM session on association request recieved"""
         pass
@@ -37,3 +41,4 @@ class ISessionCollector(ABC):
     def set_session_id(self, session_id) -> None:
         """Set an identifier to the current session"""
         pass
+


### PR DESCRIPTION
This PR logs rejected DICOM association attempts to Redis for forensic
analysis and threat intelligence correlation.

Security events are recorded at association negotiation time.

Redis key: dicom:events:assoc_rejected
Fields: timestamp, ip, calling_ae, called_ae, reason
