### PR TITLE
Update README.md with new content and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ To run DICOMHawk locally, each service should be run separately in its directory
   cd ./dicom_server
   pip install -r .\requirements.txt
   ```
+cd dicom_server
+
+# Create virtual environment (recommended for Debian/Kali systems)
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
 
 ### Starting Each Service
 
@@ -376,6 +385,7 @@ Example commands to interact with the server using DCMTK are:
 ## Access the Web API User Interface
 
      To access the Web API user interface, navigate to "http://localhost:3000" and use username and password is "test" - "test", respectively.
+
 
 
 


### PR DESCRIPTION
### Summary

This PR improves the installation instructions in the README for users on Debian-based systems (including Kali Linux).

### Problem

The current instructions recommend:

    pip install -r requirements.txt

However, on systems following PEP 668 (externally managed Python environments), this fails with:

    error: externally-managed-environment

### Changes

- Added virtual environment setup instructions
- Included note explaining why venv is required on modern Debian/Kali systems

### Impact

Improves contributor onboarding and prevents installation failures on modern Linux distributions.
