### PR TITLE
Pins the API Docker image to Node 20 LTS instead of the floating node tag.

### DIFF
--- a/API/Dockerfile
+++ b/API/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:20
 
 
 
@@ -8,5 +8,6 @@ COPY . /api/
 WORKDIR /api/.
 RUN npm install &&  npm rebuild sqlite3 && npm install redis
 EXPOSE 3000
+
 
 CMD ["node", "app.js"]


### PR DESCRIPTION
Using the unversioned node image pulls the latest Node runtime, which causes the API container to crash during startup due to incompatible dependencies (notably sqlite3 and the JWT dependency chain).

This prevents a fresh installation of DICOMHawk from running successfully on the v2.0 default branch.

Node 20 LTS restores normal behavior and allows the API to start and serve requests.

note: npm install redis could also probably be removed because its already in package dependencies