### PR TITLE
fix(c-store): improve C-STORE persistence, UID-based layout, error handling & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,58 @@ dicom_server/dicom_storage/tcia_data/modality/[StudyInstanceUID]/SeriesInstanceU
 - **DICOM_SERVER_HOST**: IP address or hostname of the DICOM server.
 - **BLOCK_SCANNERS**: Boolean to block (`yes`) or allow (`no`) known mass scanners.
 
+### C-STORE Persistence
+
+DICOMHawk accepts inbound C-STORE requests and **persists every received DICOM dataset to disk** for forensic analysis and realism.
+
+#### Storage location
+
+Files are saved under the directory specified by the `C_STORE_STORAGE` environment variable (default: `./storage/c_store_files`, relative to the runtime working directory).
+
+#### Directory structure
+
+When the received dataset contains valid Study/Series/SOP Instance UIDs the file is stored as:
+
+```
+<C_STORE_STORAGE>/<StudyInstanceUID>/<SeriesInstanceUID>/<SOPInstanceUID>.dcm
+```
+
+If any UID is absent or contains unexpected characters the server falls back to a flat timestamp-based filename:
+
+```
+<C_STORE_STORAGE>/received_<YYYY-MM-DD_HH-MM-SS.ffffff>.dcm
+```
+
+The storage directory (including any intermediate sub-directories) is created automatically if it does not exist.
+
+#### Configuration
+
+Override the default path by setting the `C_STORE_STORAGE` environment variable:
+
+```yaml
+# docker-compose.yml
+services:
+  dicom_server:
+    environment:
+      - C_STORE_STORAGE=/app/c_store_files
+    volumes:
+      - ./c_store_files:/app/c_store_files   # persist across container restarts
+```
+
+> **Docker note:** If you run DICOMHawk as a container and want uploads to survive container restarts, mount the storage directory as a named or bind-mount volume as shown above.
+
+#### Error handling
+
+If the dataset cannot be written to disk (e.g. the filesystem is full or permissions are insufficient) the server:
+1. Logs the exception via the exceptions logger.
+2. Returns DICOM status **0xA700 (Out of Resources)** to the SCU instead of falsely claiming success.
+
+#### Sending a file (example)
+
+```bash
+storescu -v -d localhost 104 /path/to/file.dcm
+```
+
 ## Threat Intelligence for the DICOM server and the Web API
 
 To enable IP reputation checks for addresses interacting with DICOMHawk, include the following environment variables in your `docker-compose.yml` file.

--- a/dicom_server/config.py
+++ b/dicom_server/config.py
@@ -70,9 +70,9 @@ BLACKHOLE_FILE_PATH = os.getenv("BLACKHOLE_FILE_PATH", "./storage/blackhole_list
 
 DICOM_STORAGE_DIR = "./storage/dicom_storage"
 
-"""DICOM files recieved through the server storage"""
+"""DICOM files recieved through the server storage (overridable via C_STORE_STORAGE env var)"""
 
-C_STORE_STORAGE = "./storage/c_store_files"
+C_STORE_STORAGE = os.getenv("C_STORE_STORAGE", "./storage/c_store_files")
 
 """DICOM server port configuration"""
 DICOM_PORT = 11112

--- a/dicom_server/core/dicom_handlers.py
+++ b/dicom_server/core/dicom_handlers.py
@@ -200,7 +200,14 @@ class DICOMHandlers:
             },
             True,
         )
-        dicom_util.store_received_file(event)
+        try:
+            dicom_util.store_received_file(event)
+        except Exception:
+            self.exceptions_logger.exception(
+                "C-STORE failed: could not persist received dataset"
+            )
+            # 0xA700 = Out of Resources — indicates server-side storage failure
+            return 0xA700
         return 0x0000
 
     def handle_move(

--- a/dicom_server/tests/test_handle_store.py
+++ b/dicom_server/tests/test_handle_store.py
@@ -1,0 +1,220 @@
+"""
+C-STORE Handler Test Suite
+
+Validates store_received_file() and handle_store() behavior:
+- UID-based directory layout when all UIDs are present
+- Timestamp-based fallback when UIDs are missing or unsafe
+- Directory auto-creation (os.makedirs)
+- handle_store() returns 0x0000 on success
+- handle_store() returns 0xA700 when the save fails
+- UID sanitization rejects path-traversal / unexpected characters
+"""
+
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+sys.path.append(os.path.abspath("../pydicom_and_pynetdicom_libs/"))
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from pydicom import Dataset
+from pydicom.dataset import FileMetaDataset
+from pydicom.uid import UID
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(study=None, series=None, sop=None, remote_ip="127.0.0.1", ae="SCU"):
+    """Build a minimal mock event as pynetdicom would pass to a C-STORE handler."""
+    ds = Dataset()
+    if study:
+        ds.StudyInstanceUID = study
+    if series:
+        ds.SeriesInstanceUID = series
+    if sop:
+        ds.SOPInstanceUID = sop
+
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = UID("1.2.840.10008.1.2.1")
+
+    assoc = MagicMock()
+    assoc.requestor.address = remote_ip
+    assoc.requestor.ae_title = ae
+
+    event = MagicMock()
+    event.dataset = ds
+    event.file_meta = file_meta
+    event.assoc = assoc
+    return event
+
+
+# ---------------------------------------------------------------------------
+# store_received_file tests
+# ---------------------------------------------------------------------------
+
+class TestStoreReceivedFile:
+
+    def test_uid_based_path_when_all_uids_present(self, tmp_path):
+        """Files are stored under Study/Series/SOP.dcm when all UIDs are valid."""
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+
+        study  = "1.2.3"
+        series = "1.2.3.4"
+        sop    = "1.2.3.4.5"
+        event  = _make_event(study=study, series=series, sop=sop)
+
+        try:
+            from utilities.dicom_util import store_received_file
+            store_received_file(event)
+        finally:
+            cfg.C_STORE_STORAGE = original
+
+        expected = tmp_path / study / series / (sop + ".dcm")
+        assert expected.exists(), f"Expected file at {expected}"
+
+    def test_timestamp_fallback_when_uid_missing(self, tmp_path):
+        """Falls back to flat received_<timestamp>.dcm when SOPInstanceUID is absent."""
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+
+        event = _make_event(study="1.2.3", series="1.2.3.4")  # no SOP UID
+
+        try:
+            from utilities.dicom_util import store_received_file
+            store_received_file(event)
+        finally:
+            cfg.C_STORE_STORAGE = original
+
+        saved = list(tmp_path.glob("received_*.dcm"))
+        assert len(saved) == 1, "Expected exactly one timestamp-based fallback file"
+
+    def test_timestamp_fallback_when_uid_unsafe(self, tmp_path):
+        """Rejects UIDs with path-traversal characters and uses timestamp fallback."""
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+
+        event = _make_event(study="../evil", series="1.2.3", sop="1.2.3.4")
+
+        try:
+            from utilities.dicom_util import store_received_file
+            store_received_file(event)
+        finally:
+            cfg.C_STORE_STORAGE = original
+
+        # No subdirectory for the unsafe study UID should be created
+        assert not (tmp_path / "../evil").exists()
+        saved = list(tmp_path.glob("received_*.dcm"))
+        assert len(saved) == 1
+
+    def test_directory_created_automatically(self, tmp_path):
+        """os.makedirs is called so missing intermediate directories are created."""
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        deep_dir = tmp_path / "new_root"
+        cfg.C_STORE_STORAGE = str(deep_dir)
+
+        event = _make_event(study="1.1", series="2.2", sop="3.3")
+
+        try:
+            from utilities.dicom_util import store_received_file
+            store_received_file(event)
+        finally:
+            cfg.C_STORE_STORAGE = original
+
+        assert (deep_dir / "1.1" / "2.2" / "3.3.dcm").exists()
+
+    def test_raises_on_save_failure(self, tmp_path):
+        """store_received_file propagates exceptions so handle_store can react."""
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+
+        event = _make_event(study="1.1", series="2.2", sop="3.3")
+
+        with patch("pydicom.Dataset.save_as", side_effect=OSError("disk full")):
+            try:
+                from utilities.dicom_util import store_received_file
+                with pytest.raises(OSError):
+                    store_received_file(event)
+            finally:
+                cfg.C_STORE_STORAGE = original
+
+
+# ---------------------------------------------------------------------------
+# handle_store tests
+# ---------------------------------------------------------------------------
+
+class TestHandleStore:
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        """Import app_container lazily so sys.path additions take effect first."""
+        import app_container
+        container = app_container.ApplicationContainer()
+        self.handlers = container.dicom_handlers()
+
+    def _make_store_event(self, **kwargs):
+        return _make_event(**kwargs)
+
+    def test_returns_success_on_save(self, tmp_path):
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+        event = self._make_store_event(study="1.1", series="2.2", sop="3.3")
+        try:
+            result = self.handlers.handle_store(event)
+        finally:
+            cfg.C_STORE_STORAGE = original
+        assert result == 0x0000
+
+    def test_returns_out_of_resources_on_failure(self, tmp_path):
+        import config as cfg
+        original = cfg.C_STORE_STORAGE
+        cfg.C_STORE_STORAGE = str(tmp_path)
+        event = self._make_store_event(study="1.1", series="2.2", sop="3.3")
+        with patch(
+            "utilities.dicom_util.store_received_file",
+            side_effect=OSError("cannot write"),
+        ):
+            try:
+                result = self.handlers.handle_store(event)
+            finally:
+                cfg.C_STORE_STORAGE = original
+        # 0xA700 = Out of Resources
+        assert result == 0xA700
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_uid unit tests
+# ---------------------------------------------------------------------------
+
+class TestSanitizeUid:
+
+    def _fn(self):
+        from utilities.dicom_util import _sanitize_uid
+        return _sanitize_uid
+
+    def test_valid_uid(self):
+        assert self._fn()("1.2.840.10008.1.2") == "1.2.840.10008.1.2"
+
+    def test_none_returns_none(self):
+        assert self._fn()(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert self._fn()("") is None
+
+    def test_path_traversal_returns_none(self):
+        assert self._fn()("../etc/passwd") is None
+
+    def test_uid_with_letters_returns_none(self):
+        assert self._fn()("1.abc.2") is None
+
+
+pytest.main(["-v", "test_handle_store.py"])

--- a/dicom_server/utilities/dicom_util.py
+++ b/dicom_server/utilities/dicom_util.py
@@ -89,11 +89,62 @@ def file_compressed(instance):
     return instance.file_meta.TransferSyntaxUID.is_compressed
 
 
+_UID_SAFE_RE = __import__("re").compile(r"^[0-9.]+$")
+
+
+def _sanitize_uid(uid):
+    """Return *uid* as a string if it contains only digits and dots, else None."""
+    s = str(uid).strip() if uid else ""
+    return s if (s and _UID_SAFE_RE.match(s)) else None
+
+
 def store_received_file(event):
-    file_name = "received_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")
-    event.dataset.file_meta = event.file_meta
-    event.dataset.save_as(
-        os.path.join(config.C_STORE_STORAGE, file_name), write_like_original=False
+    """Persist the C-STORE dataset to disk.
+
+    Storage layout (when all UIDs are present):
+        <C_STORE_STORAGE>/<StudyInstanceUID>/<SeriesInstanceUID>/<SOPInstanceUID>.dcm
+
+    Falls back to a flat timestamp-based filename when any UID is missing or
+    contains unexpected characters.
+
+    Raises on I/O failure so the caller can return an appropriate DICOM error
+    status instead of silently claiming success.
+    """
+    ds = event.dataset
+
+    study_uid  = _sanitize_uid(getattr(ds, "StudyInstanceUID",  None))
+    series_uid = _sanitize_uid(getattr(ds, "SeriesInstanceUID", None))
+    sop_uid    = _sanitize_uid(getattr(ds, "SOPInstanceUID",    None))
+
+    # Derive caller identity for logging (best-effort)
+    try:
+        remote_ip = str(event.assoc.requestor.address)
+        remote_ae = str(event.assoc.requestor.ae_title).strip()
+    except Exception:
+        remote_ip, remote_ae = "unknown", "unknown"
+
+    if study_uid and series_uid and sop_uid:
+        dest_dir  = os.path.join(config.C_STORE_STORAGE, study_uid, series_uid)
+        file_path = os.path.join(dest_dir, sop_uid + ".dcm")
+    else:
+        dest_dir  = config.C_STORE_STORAGE
+        file_path = os.path.join(
+            dest_dir,
+            "received_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f") + ".dcm",
+        )
+
+    exceptions_logger.debug(
+        "C-STORE incoming | remote=%s AE=%s | study=%s series=%s sop=%s",
+        remote_ip, remote_ae, study_uid, series_uid, sop_uid,
+    )
+
+    os.makedirs(dest_dir, exist_ok=True)
+    ds.file_meta = event.file_meta
+    ds.save_as(file_path, write_like_original=False)
+
+    exceptions_logger.info(
+        "C-STORE saved | path=%s | remote=%s AE=%s | study=%s series=%s sop=%s",
+        file_path, remote_ip, remote_ae, study_uid, series_uid, sop_uid,
     )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       - TCIA_STUDIES_PER_MODALITY=10
       - DOCKER=yes
       - HONEY_URL="https://[YOURHONEYURL]"
+      # C-STORE uploads are persisted to this path inside the container.
+      # Override and add a bind-mount volume below to keep files across restarts.
+      - C_STORE_STORAGE=/app/c_store_files
     build: ./dicom_server/.
     volumes:
       - shared_data:/app


### PR DESCRIPTION
## Summary

Resolves #96 — C-STORE uploads are now properly persisted, configurable, and documented.

---

## Before / After

| Aspect | Before | After |
|---|---|---|
| Storage path | Hard-coded `./storage/c_store_files` constant | Configurable via `C_STORE_STORAGE` env var (same default) |
| File naming | Flat `received_<timestamp>` (no extension) | `<StudyUID>/<SeriesUID>/<SOPUID>.dcm` with timestamp fallback |
| Directory creation | Silent failure if dir missing | `os.makedirs(..., exist_ok=True)` auto-creates |
| Path safety | No sanitization | UIDs validated to `[0-9.]` only; path traversal rejected |
| On I/O failure | Always returned `0x0000` (Success) | Returns `0xA700` (Out of Resources) + logs exception |
| Logging | None | Logs path, UIDs, remote IP & AE title on save/failure |
| Documentation | No mention of C-STORE file storage | New README section with location, layout, env var, Docker note |
| Tests | No C-STORE tests | New `test_handle_store.py` covering all scenarios above |

---

## Changes

### `dicom_server/config.py`
- `C_STORE_STORAGE` is now read from the `C_STORE_STORAGE` environment variable (default unchanged: `./storage/c_store_files`).

### `dicom_server/utilities/dicom_util.py`
- `store_received_file()` stores under `<Study>/<Series>/<SOP>.dcm` when all UIDs are present; falls back to a timestamp filename.
- UIDs are sanitized to `[0-9.]` before use as path components.
- `os.makedirs(dest_dir, exist_ok=True)` ensures the directory is created automatically.
- Remote IP and AE title are logged along with the saved path and UIDs.
- Raises on I/O failure so `handle_store()` can propagate the error.

### `dicom_server/core/dicom_handlers.py`
- `handle_store()` wraps `store_received_file()` in a try/except and returns `0xA700` (Out of Resources) on failure.

### `dicom_server/tests/test_handle_store.py` *(new)*
- Unit tests for UID-based path layout, timestamp fallback, auto directory creation, UID sanitization, success status and failure status.

### `README.md`
- New **"C-STORE Persistence"** sub-section under DICOM Server configuration explaining default location, directory structure, `C_STORE_STORAGE` env var, Docker volume recommendation, and error handling.

### `docker-compose.yml`
- Added `C_STORE_STORAGE=/app/c_store_files` with explanatory comment to the `dicom_server` service environment.