### PR TITLE
fix: implement jail + quarantine system to close C-STORE path traversal (fixes #114)

### DIFF
--- a/src/dicomhawk/repository.py
+++ b/src/dicomhawk/repository.py
@@ -16,9 +16,14 @@ from .storage import Storage
 from .honey import Middleware
 
 import os
+import hashlib
 import logging
 
 logger = logging.getLogger(__name__)
+
+def _hash_uid(uid: str) -> str:
+    # hash uid with sha256 to avoid path traversal
+    return hashlib.sha256(uid.encode()).hexdigest()
 
 class QRError:
     error: str
@@ -135,7 +140,7 @@ class Repository:
                 self.storage.compress(tf)
 
         fdir = self.storage.jail(safe)
-        fname = ds.SOPInstanceUID # NOTE: this is dangerous
+        fname = _hash_uid(str(ds.SOPInstanceUID))
         fpath = os.path.join(fdir, fname)
 
         if os.path.exists(fpath):
@@ -171,6 +176,20 @@ class Repository:
     def find_instance(self, match: Dataset, decompress: bool = False, inject: bool = True) -> FindResult:
         result = FindResult()
 
+        # don't allow retrieving quarantined files
+        if self.storage.is_quarantined(match.filename):
+            err = QRError()
+            err.error = (
+                f"Retrieval denied: instance '{match.filename}' is quarantined. "
+                "Only pre-loaded honeypot data may be retrieved."
+            )
+            err.status = QRStatus.FAILURE
+            result.error = err
+            logger.warning(
+                "Blocked C-GET/C-MOVE for quarantined file: %s", match.filename
+            )
+            return result
+
         try:
             instance = dcmread(match.filename)
         except Exception as exc:
@@ -180,7 +199,6 @@ class Repository:
             result.error = err
             return result
         
-        # NOTE: not sure this is needed tbh, why not sending files compressed?
         if decompress and instance.file_meta.TransferSyntaxUID.is_compressed:
             instance.decompress()
             apply_modality_lut(instance.pixel_array, instance)

--- a/src/dicomhawk/server.py
+++ b/src/dicomhawk/server.py
@@ -54,7 +54,7 @@ class Server:
         handler_factory = new_handler_factory()
         self.handlers = self.make_handlers(handler_factory)
 
-    def make_handlers(self, handlers: HandlerFactory):
+    def make_handlers(self, handlers: dict):
         # TODO: the config should have a list of supported operations
         return [
             (evt.EVT_ACSE_RECV, handlers.get("associate")),

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -8,18 +8,40 @@ from datetime import datetime
 from uuid import uuid4
 
 class Storage:
-    storage_dir: str
-    quarantine_dir: str
+    def __init__(
+        self,
+        traces: str,
+        storage: str = None,
+        quarantine: str = None,
+    ) -> None:
+        import os
+        docker = os.getenv("DOCKER", "").lower() in ("1", "true", "yes")
 
-    def __init__(self, traces: str) -> None:
         self.traces_dir = Path(traces)
         self.traces_dir.mkdir(parents=True, exist_ok=True)
 
-    def jail(self, safe: bool = False) -> str:
+        # default to the paths already used in the config
+        _storage   = storage   or ("/opt/dicomhawk/storage/dicom_storage"  if docker else "./storage/dicom_storage")
+        _quarantine = quarantine or ("/opt/dicomhawk/storage/c_store_files" if docker else "./storage/c_store_files")
+
+        self.storage_dir = Path(_storage)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+        self.quarantine_dir = Path(_quarantine)
+        self.quarantine_dir.mkdir(parents=True, exist_ok=True)
+
+    def jail(self, safe: bool = False) -> Path:
         if safe:
             return self.storage_dir
         return self.quarantine_dir
-    
+
+    def is_quarantined(self, filepath: str | Path) -> bool:
+        try:
+            Path(filepath).resolve().relative_to(self.quarantine_dir.resolve())
+            return True
+        except ValueError:
+            return False
+
     @contextmanager
     def temp(self, suffix=".dcm"):
         date_name = datetime.now().strftime("%YY%mm%dd_%HH%MM%SS")


### PR DESCRIPTION
Picked up from #114 — implemented the actual jail + quarantine split that was missing.

Right now `Storage.jail()` references `storage_dir` and `quarantine_dir` that are never set, so any C-STORE call would crash. More importantly, the filename came straight from `ds.SOPInstanceUID` with no sanitization, which is the path traversal issue.

Changes:
- `storage.py` — wired up real directories in `__init__`. `jail()` now actually routes to them. Added `is_quarantined()` to check if a file lives in quarantine.
- `repository.py` — switched to hashing the UID (SHA-256) instead of using it raw as a filename. Also added a quarantine check in `find_instance()` so attacker uploads can't be pulled back out via C-GET/C-MOVE.
- `server.py` — minor: fixed a `NameError` on `HandlerFactory` that was breaking imports.

Closes #114