### PR TITLE
feat: wire up EventLogger to the main application bus (fixes missing logs & CLI crash)

### DIFF
--- a/src/commands/serve.py
+++ b/src/commands/serve.py
@@ -4,6 +4,7 @@ from dicomhawk.handlers import new_dimse_factory
 from dicomhawk.middlewares import Middleware
 from dicomhawk.repository import new_repo
 from dicomhawk.server import new_config, new_server
+from dicomhawk.event_logger import new_bus
 from dicomhawk.storage import new_store
 
 serve_app = typer.Typer(help="dicomhawk runner")
@@ -52,6 +53,12 @@ def serve(
             "--database",
             help="path to database"
         ),
+        log_path: str = typer.Option(
+            "data/dicomhawk.log",
+            "-l",
+            "--log-path",
+            help="path to the JSON event log file"
+        ),
         traces : str = typer.Option(
             "traces",
             "-t",
@@ -72,7 +79,7 @@ def serve(
     store = new_store(traces)
     mws: list[Middleware] = [] # TODO: fix this, add a middleware to inject the honeytoken
     repo = new_repo(database, store, mws)
-    bus = new_bus() # TODO: make the bus
+    bus = new_bus(log_path)
 
     dimse_fact = new_dimse_factory(repo, bus)
 

--- a/src/dicomhawk/event_logger.py
+++ b/src/dicomhawk/event_logger.py
@@ -48,3 +48,7 @@ class EventLogger:
                 f.write(json.dumps(fields) + "\n")
         except OSError as exc:
             _log.error("Failed to write event log entry: %s", exc)
+
+
+def new_bus(path: str) -> EventLogger:
+    return EventLogger(path)

--- a/src/dicomhawk/handlers.py
+++ b/src/dicomhawk/handlers.py
@@ -237,7 +237,7 @@ class DIMSEFactory:
         self.handlers: dict[str, EventHandlerType] = {}
 
     def get(self, name: str) -> EventHandlerType | None:
-        if handler := self.handlers[name]:
+        if handler := self.handlers.get(name):
             return handler
     
     def register(self, name: str, handler: EventHandlerType) -> 'DIMSEFactory':

--- a/src/dicomhawk/server.py
+++ b/src/dicomhawk/server.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import logging
 from copy import copy
-from logging import Logger
+from .event_logger import EventLogger
 from itertools import chain
 from pynetdicom import (
     evt,
@@ -45,7 +45,7 @@ class Server:
 
     def __init__(
             self, 
-            bus: Logger,
+            bus: EventLogger,
             config: ServerConfig,
             handlers: list[EventHandlerType],
         ):
@@ -123,5 +123,5 @@ class Server:
         for srv in self.listeners:
             srv.shutdown()
 
-def new_server(bus: Logger, config: ServerConfig, handlers: list[EventHandlerType]) -> Server:
+def new_server(bus: EventLogger, config: ServerConfig, handlers: list[EventHandlerType]) -> Server:
     return Server(bus, config, handlers)


### PR DESCRIPTION
Hi @RicYaben, 

As we discussed, this PR wires up the `EventLogger` we built into the main application so it can start recording live events.

Here is what I did:
* Replaced the `bus = new_bus()` placeholder in `serve.py` so it actually initializes our logger.
* Added a simple `new_bus` function in `event_logger.py` to match the existing component architecture. 
* Added a `--log-path` argument to the CLI.

While doing end-to-end testing locally, I also found a small bug that caused the server to crash:
If you ran the `serve` command with the default arguments, the `DIMSEFactory` would try to load handlers that haven't been implemented yet using `self.handlers[name]`, which threw a `KeyError`. I fixed this by changing it to `self.handlers.get(name)` in `handlers.py`, so the server now boots up safely and gracefully ignores missing handlers.

I spun up a local test environment and fired a real C-FIND payload at the server to verify everything. It intercepted the request without crashing and successfully wrote the correct JSON event to the log file. 

Please have a look and let me know if any changes are required :) 

Once this is merged, I will move on to the Honeytoken Middleware!
