### PR TITLE
fix(storage): jail payloads with path-jail, init storage/quarantine dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pytz",
     "overpy",
     "sqlalchemy",
-    "typer",
+    "typer", 
     "numpy",
     # for the web
     "flask",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "overpy",
     "sqlalchemy",
     "typer",
-    "path-jail",
     "numpy",
     # for the web
     "flask",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "pytz",
     "overpy",
     "sqlalchemy",
-    "typer", 
+    "typer",
+    "path-jail",
     "numpy",
     # for the web
     "flask",

--- a/src/dicomhawk/repository.py
+++ b/src/dicomhawk/repository.py
@@ -1,4 +1,3 @@
-
 from pydicom import dcmread
 from pydicom.uid import UID
 from pydicom.dataset import Dataset
@@ -15,7 +14,6 @@ from .status import QRStatus
 from .storage import Storage
 from .middlewares import Middleware
 
-import os
 import logging
 
 logger = logging.getLogger(__name__)
@@ -134,11 +132,18 @@ class Repository:
                 ds.save_as(tf, enforce_file_format=False)
                 self.storage.compress(tf)
 
-        fdir = self.storage.jail(safe)
-        fname = ds.SOPInstanceUID # NOTE: this is dangerous
-        fpath = os.path.join(fdir, fname)
+        fname = str(ds.SOPInstanceUID)
 
-        if os.path.exists(fpath):
+        try:
+            fpath = self.storage.path_for(safe, fname)
+        except ValueError as exc:
+            logger.warning(f"Path traversal attempt blocked: {fname} — {exc}")
+            err = QRError()
+            err.error = f"Dangerous SOPInstanceUID rejected: {fname}"
+            err.status = QRStatus.STORE_ERROR
+            return err
+
+        if fpath.exists():
             logger.warning(f"Instance already exists in storage directory: {fname}; overwriting")
 
         try:
@@ -157,7 +162,7 @@ class Repository:
                 .all()
             )
 
-            db.add_instance(ds, self.conn, os.path.abspath(fpath))
+            db.add_instance(ds, self.conn, str(fpath.resolve()))
             if not matches:
                 logger.info("Instance added to database")
             else:

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -8,21 +8,11 @@ from datetime import datetime
 from uuid import uuid4
 
 
-def _jailed_path(root: Path, filename: str) -> Path:
-    """Resolve path under root. Raises ValueError if it would escape the jail."""
-    if Path(filename).is_absolute():
-        raise ValueError("filename must be relative")
-    root_resolved = root.resolve()
-    full = (root / filename).resolve()
-    if not full.is_relative_to(root_resolved):
-        raise ValueError("path escapes jail")
-    return full
-
-
 class Storage:
     def __init__(self, traces: str) -> None:
         self.traces_dir = Path(traces)
         self.traces_dir.mkdir(parents=True, exist_ok=True)
+        # Initialize storage and quarantine directories
         self.storage_dir = self.traces_dir / "storage"
         self.quarantine_dir = self.traces_dir / "quarantine"
         self.storage_dir.mkdir(parents=True, exist_ok=True)
@@ -33,10 +23,60 @@ class Storage:
             return str(self.storage_dir)
         return str(self.quarantine_dir)
 
+    def _jailed_path(self, root: Path, filename: str) -> Path:
+        """
+        Resolve a path within the jail directory.
+        
+        Validates that the resolved path remains within the jail boundary,
+        preventing path traversal attacks via crafted filenames.
+        
+        Args:
+            root: The jail root directory (storage_dir or quarantine_dir)
+            filename: The filename to validate
+            
+        Returns:
+            Path: The resolved path if valid
+            
+        Raises:
+            ValueError: If filename is absolute or would escape the jail,
+                       including the problematic filename and resolved path
+                       in the error message for debugging.
+        """
+        if Path(filename).is_absolute():
+            raise ValueError(
+                f"Absolute paths not allowed in jail. Got: {filename}"
+            )
+        
+        root_resolved = root.resolve()
+        full = (root / filename).resolve()
+        
+        if not full.is_relative_to(root_resolved):
+            raise ValueError(
+                f"Path traversal detected: filename '{filename}' resolved to "
+                f"'{full}' which escapes jail boundary '{root_resolved}'"
+            )
+        
+        return full
+
     def path_for(self, safe: bool, filename: str) -> Path:
-        """Path inside the jail for filename. Raises ValueError if path would escape."""
+        """
+        Get a jailed path for the given filename.
+        
+        Routes to either storage_dir (safe=True) or quarantine_dir (safe=False).
+        Validates that the path remains within the jail boundary.
+        
+        Args:
+            safe: If True, use storage_dir; if False, use quarantine_dir
+            filename: The filename to jail
+            
+        Returns:
+            Path: The validated jailed path
+            
+        Raises:
+            ValueError: If the filename would escape the jail
+        """
         root = self.storage_dir if safe else self.quarantine_dir
-        return _jailed_path(root, filename)
+        return self._jailed_path(root, filename)
     
     @contextmanager
     def temp(self, suffix=".dcm"):

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -7,18 +7,29 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-class Storage:
-    storage_dir: str
-    quarantine_dir: str
+from path_jail import Jail
 
+
+class Storage:
     def __init__(self, traces: str) -> None:
         self.traces_dir = Path(traces)
         self.traces_dir.mkdir(parents=True, exist_ok=True)
+        self.storage_dir = self.traces_dir / "storage"
+        self.quarantine_dir = self.traces_dir / "quarantine"
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.quarantine_dir.mkdir(parents=True, exist_ok=True)
+        self._jail_storage = Jail(self.storage_dir)
+        self._jail_quarantine = Jail(self.quarantine_dir)
 
     def jail(self, safe: bool = False) -> str:
         if safe:
-            return self.storage_dir
-        return self.quarantine_dir
+            return str(self.storage_dir)
+        return str(self.quarantine_dir)
+
+    def path_for(self, safe: bool, filename: str) -> Path:
+        """Path inside the jail for filename. Raises ValueError if path would escape."""
+        j = self._jail_storage if safe else self._jail_quarantine
+        return Path(j.join(filename))
     
     @contextmanager
     def temp(self, suffix=".dcm"):

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -7,7 +7,16 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from path_jail import Jail
+
+def _jailed_path(root: Path, filename: str) -> Path:
+    """Resolve path under root. Raises ValueError if it would escape the jail."""
+    if Path(filename).is_absolute():
+        raise ValueError("filename must be relative")
+    root_resolved = root.resolve()
+    full = (root / filename).resolve()
+    if not full.is_relative_to(root_resolved):
+        raise ValueError("path escapes jail")
+    return full
 
 
 class Storage:
@@ -18,8 +27,6 @@ class Storage:
         self.quarantine_dir = self.traces_dir / "quarantine"
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.quarantine_dir.mkdir(parents=True, exist_ok=True)
-        self._jail_storage = Jail(self.storage_dir)
-        self._jail_quarantine = Jail(self.quarantine_dir)
 
     def jail(self, safe: bool = False) -> str:
         if safe:
@@ -28,8 +35,8 @@ class Storage:
 
     def path_for(self, safe: bool, filename: str) -> Path:
         """Path inside the jail for filename. Raises ValueError if path would escape."""
-        j = self._jail_storage if safe else self._jail_quarantine
-        return Path(j.join(filename))
+        root = self.storage_dir if safe else self.quarantine_dir
+        return _jailed_path(root, filename)
     
     @contextmanager
     def temp(self, suffix=".dcm"):

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -12,7 +12,6 @@ class Storage:
     def __init__(self, traces: str) -> None:
         self.traces_dir = Path(traces)
         self.traces_dir.mkdir(parents=True, exist_ok=True)
-        # Initialize storage and quarantine directories
         self.storage_dir = self.traces_dir / "storage"
         self.quarantine_dir = self.traces_dir / "quarantine"
         self.storage_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #129

I've implemented Pure-Python filesystem jail for `Storage` and wired into `Repository.store()` to block path-traversal via crafted `SOPInstanceUID`. Zero external dependencies — stdlib `pathlib` only.

## Changes i've made so far

- **`storage.py`** — init `storage_dir`/`quarantine_dir` in `__init__`, add `_jailed_path()` using `Path.resolve()` + `is_relative_to()`, expose via `path_for()`
- **`repository.py`** — `store()` routes through `path_for()` instead of raw `os.path.join`; traversal attempts return `QRError`
- **`pyproject.toml`** — removed `path-jail` (net zero from upstream) 

let me know if this requires some changes :)