### PR TITLE
feat(stix): map EventBus logs to STIX 2.1 Bundles via --stix-out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+stix = [
+    "stix2>=3.0.0",
+]
 dev = [
     "pytest",
     "faker",
+    "stix2>=3.0.0",
 ]
 
 [tool.setuptools]

--- a/src/commands/serve.py
+++ b/src/commands/serve.py
@@ -74,6 +74,11 @@ def serve(
             None,
             "--canary-pdf",
             help="Path to an Encapsulated PDF Canary to inject into datasets"
+        ),
+        stix_out: str | None = typer.Option(
+            None,
+            "--stix-out",
+            help="Directory to write STIX 2.1 Bundle JSON (NDJSON) output"
         )
     ):
 
@@ -92,7 +97,13 @@ def serve(
     mws: list[Middleware] = [injector]
     
     repo = new_repo(database, store, mws)
-    bus = new_bus(log_path)
+
+    stix_identity = None
+    if stix_out:
+        from dicomhawk.stix import new_honeypot_identity
+        stix_identity = new_honeypot_identity(ae_title, impl_uid)
+
+    bus = new_bus(log_path, stix_out=stix_out, stix_identity=stix_identity)
 
     dimse_fact = new_dimse_factory(repo, bus)
 

--- a/src/commands/serve.py
+++ b/src/commands/serve.py
@@ -1,7 +1,7 @@
 import typer
 from dicomhawk.app import new_dicomhawk
 from dicomhawk.handlers import new_dimse_factory
-from dicomhawk.middlewares import Middleware
+from dicomhawk.middlewares import Middleware, new_honeytoken_injector
 from dicomhawk.repository import new_repo
 from dicomhawk.server import new_config, new_server
 from dicomhawk.bus import new_bus
@@ -64,6 +64,16 @@ def serve(
             "-t",
             "--traces",
             help="Where to store traces (i.e., DICOM files and uploaded payloads)"
+        ),
+        honey_url: str | None = typer.Option(
+            None,
+            "--honey-url",
+            help="URL to inject as RetrieveURL for Honey URLs"
+        ),
+        canary_pdf: str | None = typer.Option(
+            None,
+            "--canary-pdf",
+            help="Path to an Encapsulated PDF Canary to inject into datasets"
         )
     ):
 
@@ -77,7 +87,10 @@ def serve(
     )
 
     store = new_store(traces)
-    mws: list[Middleware] = [] # TODO: fix this, add a middleware to inject the honeytoken
+    
+    injector = new_honeytoken_injector(honey_url, canary_pdf)
+    mws: list[Middleware] = [injector]
+    
     repo = new_repo(database, store, mws)
     bus = new_bus(log_path)
 

--- a/src/dicomhawk/bus.py
+++ b/src/dicomhawk/bus.py
@@ -78,7 +78,14 @@ def config_bus_size_rotation(bus: Logger, stdout: str, size: int = 1024) -> Logg
     bus.addHandler(h)
     return bus
 
-def new_bus(stdout: Optional[str] = None, when: Optional[str] = None, interval: int = 1, size: Optional[int] = None) -> Logger:
+def new_bus(
+    stdout: Optional[str] = None,
+    when: Optional[str] = None,
+    interval: int = 1,
+    size: Optional[int] = None,
+    stix_out: Optional[str] = None,
+    stix_identity=None,
+) -> Logger:
     lg = logging.getLogger("bus")
     if not stdout:
         return lg
@@ -91,5 +98,9 @@ def new_bus(stdout: Optional[str] = None, when: Optional[str] = None, interval: 
 
     if size:
         lg = config_bus_size_rotation(lg, stdout, size)
+
+    if stix_out and stix_identity:
+        from .stix import StixHandler
+        lg.addHandler(StixHandler(stix_identity, stix_out))
 
     return lg

--- a/src/dicomhawk/middlewares.py
+++ b/src/dicomhawk/middlewares.py
@@ -1,6 +1,38 @@
+import logging
 from typing import Callable
 from pydicom.dataset import Dataset
+from pydicom import uid
+
+logger = logging.getLogger(__name__)
 
 type Middleware = Callable[[Dataset], Dataset]
 
-def inject_honeytoken(ds: Dataset) -> Dataset: ...
+def new_honeytoken_injector(honey_url: str | None = None, pdf_path: str | None = None) -> Middleware:
+    canary_data = None
+    if pdf_path:
+        try:
+            with open(pdf_path, "rb") as f:
+                canary_data = f.read()
+            logger.info("Loaded Canary PDF")
+        except Exception as e:
+            logger.error(f"Failed to read Canary PDF: {e}")
+
+    def inject_honeytoken(ds: Dataset) -> Dataset:
+        if honey_url:
+            study_uid = ds.get("StudyInstanceUID", "UNKNOWN_STUDY")
+            try:
+                ds.RetrieveURL = f"{str(honey_url).rstrip('/')}/{study_uid}"
+            except Exception as e:
+                logger.error(f"Failed to inject Honey URL: {e}")
+            
+        if canary_data:
+            try:
+                ds.SOPClassUID = uid.EncapsulatedPDFStorage
+                ds.MIMETypeOfEncapsulatedDocument = "application/pdf"
+                ds.EncapsulatedDocument = canary_data
+            except Exception as e:
+                logger.error(f"Failed to inject Canary PDF: {e}")
+            
+        return ds
+
+    return inject_honeytoken

--- a/src/dicomhawk/stix.py
+++ b/src/dicomhawk/stix.py
@@ -1,0 +1,178 @@
+import logging
+from datetime import timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+try:
+    import stix2
+except ImportError as exc:
+    raise ImportError(
+        "STIX 2.1 export requires the 'stix2' package. "
+        "Install it with: pip install 'dicomhawk[stix]'"
+    ) from exc
+
+# Maps pynetdicom event names to STIX AttackPattern descriptors.
+_EVENT_PATTERNS: dict[str, dict] = {
+    "EVT_C_STORE": {
+        "name": "DICOM Unauthorized Data Ingestion (C-STORE)",
+        "description": (
+            "An attacker pushed a DICOM SOP instance to the honeypot via C-STORE, "
+            "indicating a potential unauthorized data upload or exfiltration-staging attack vector."
+        ),
+    },
+    "EVT_C_FIND": {
+        "name": "DICOM Patient Index Enumeration (C-FIND)",
+        "description": (
+            "An attacker issued a C-FIND query to enumerate stored patient study identifiers, "
+            "indicating reconnaissance of stored medical data."
+        ),
+    },
+    "EVT_C_GET": {
+        "name": "DICOM Patient Data Exfiltration (C-GET)",
+        "description": (
+            "An attacker issued a C-GET request to retrieve stored DICOM SOP instances, "
+            "indicating an active patient data exfiltration attempt."
+        ),
+    },
+    "EVT_C_MOVE": {
+        "name": "DICOM Lateral Data Exfiltration (C-MOVE)",
+        "description": (
+            "An attacker issued a C-MOVE request to redirect stored DICOM files to a third-party AE, "
+            "indicating an attempt at lateral data exfiltration."
+        ),
+    },
+    "EVT_ACSE_RECV": {
+        "name": "DICOM Server Reconnaissance (A-ASSOCIATE-RQ)",
+        "description": (
+            "A remote host opened a DICOM A-ASSOCIATE request without issuing a DIMSE command, "
+            "consistent with automated scanner reconnaissance (e.g., Shodan, Nmap dicom-ping)."
+        ),
+    },
+    "EVT_RELEASED": {
+        "name": "DICOM Association Released",
+        "description": (
+            "A DICOM association was cleanly released, marking the end of an attacker session."
+        ),
+    },
+    "EVT_ABORTED": {
+        "name": "DICOM Association Aborted",
+        "description": (
+            "A DICOM association was abruptly aborted, which may indicate a crashed scanner, "
+            "a failed attack tool, or defensive detection on the attacker side."
+        ),
+    },
+}
+
+_DICOM_STANDARD_REF = {
+    "source_name": "DICOM Standard",
+    "url": "https://www.dicomstandard.org/current/",
+    "description": "NEMA DICOM PS3 — Digital Imaging and Communications in Medicine",
+}
+
+
+def new_honeypot_identity(ae_title: str = "DICOMHawk", impl_uid: str = "1.2.3.4") -> stix2.Identity:
+    """Creates the singleton STIX 2.1 Identity SDO for this DICOMHawk deployment.
+    Call once at server startup and pass to to_stix_bundle()."""
+    return stix2.Identity(
+        name=f"DICOMHawk Honeypot [{ae_title}]",
+        identity_class="system",
+        description=f"DICOMHawk DICOM honeypot server. AE Title: {ae_title}, Implementation UID: {impl_uid}.",
+    )
+
+
+def to_stix_bundle(msg, identity: stix2.Identity) -> stix2.Bundle:
+    """Converts an EventMessage to a valid STIX 2.1 Bundle."""
+    # NOTE: pynetdicom's datetime.now() is naive; STIX requires UTC-aware timestamps
+    ts = msg.timestamp.replace(tzinfo=timezone.utc)
+
+    src_ip = stix2.IPv4Address(value=msg.evt.assoc.requestor.address)
+    dst_ip = stix2.IPv4Address(value=msg.evt.assoc.acceptor.address)
+
+    traffic = stix2.NetworkTraffic(
+        src_ref=src_ip.id,
+        dst_ref=dst_ip.id,
+        src_port=msg.evt.assoc.requestor.port,
+        dst_port=msg.evt.assoc.acceptor.port,
+        protocols=["tcp"],
+    )
+
+    event_name = msg.evt._event.name
+    pattern_info = _EVENT_PATTERNS.get(event_name, {
+        "name": f"Unknown DICOM Event ({event_name})",
+        "description": f"Unclassified DICOM event: {event_name}",
+    })
+
+    attack = stix2.AttackPattern(
+        name=pattern_info["name"],
+        description=pattern_info["description"],
+        created_by_ref=identity.id,
+        external_references=[_DICOM_STANDARD_REF],
+    )
+
+    observed = stix2.ObservedData(
+        first_observed=ts,
+        last_observed=ts,
+        number_observed=1,
+        object_refs=[src_ip.id, dst_ip.id, traffic.id],
+        created_by_ref=identity.id,
+    )
+
+    # Sighting ties together: what we saw, what attack it maps to, and where we saw it
+    sighting = stix2.Sighting(
+        sighting_of_ref=attack.id,
+        observed_data_refs=[observed.id],
+        where_sighted_refs=[identity.id],
+        first_seen=ts,
+        last_seen=ts,
+        count=1,
+        created_by_ref=identity.id,
+    )
+
+    return stix2.Bundle(
+        objects=[identity, src_ip, dst_ip, traffic, attack, observed, sighting],
+    )
+
+
+class StixHandler(logging.Handler):
+    """Intercepts EventMessage log records and writes STIX 2.1 Bundle JSON
+    (one bundle per line / NDJSON) to a rotating output file."""
+
+    def __init__(self, identity: stix2.Identity, stix_out: str) -> None:
+        super().__init__()
+        # NOTE: logging.Handler defaults to WARNING; bus.info() fires at INFO level
+        self.setLevel(logging.INFO)
+
+        from .bus import EventMessage  # local import to avoid circular dependency
+
+        self._identity = identity
+        self._EventMessage = EventMessage
+
+        out_dir = Path(stix_out)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / "stix.ndjson"
+
+        self._file_handler = RotatingFileHandler(
+            str(out_path),
+            maxBytes=10 * 1024 * 1024,  # 10 MB per file
+            backupCount=5,
+        )
+        self._file_handler.setFormatter(logging.Formatter("%(message)s"))  # pass message through as-is
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if not isinstance(record.msg, self._EventMessage):
+            return
+        try:
+            bundle = to_stix_bundle(record.msg, self._identity)
+            # wrap in a fresh LogRecord so RotatingFileHandler runs its own
+            # size check and doRollover() rather than us doing it manually
+            stix_record = logging.makeLogRecord({
+                "msg": bundle.serialize(),
+                "args": (),
+            })
+            self._file_handler.emit(stix_record)
+        except Exception:
+            self.handleError(record)
+
+    def close(self) -> None:
+        self._file_handler.close()
+        super().close()

--- a/tests/test_stix.py
+++ b/tests/test_stix.py
@@ -1,0 +1,263 @@
+"""Tests for the STIX 2.1 converter (stix.py)."""
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+import stix2
+
+from dicomhawk.stix import (
+    _EVENT_PATTERNS,
+    new_honeypot_identity,
+    to_stix_bundle,
+)
+
+
+def _make_fake_event(
+    src_ip="93.184.216.34",
+    src_port=52000,
+    dst_ip="10.0.0.1",
+    dst_port=104,
+    event_name="EVT_C_STORE",
+):
+    """Builds a minimal pynetdicom Event mock that satisfies the converter."""
+    fake_assoc = MagicMock()
+    fake_assoc.requestor.address = src_ip
+    fake_assoc.requestor.port = src_port
+    fake_assoc.acceptor.address = dst_ip
+    fake_assoc.acceptor.port = dst_port
+
+    fake_event_type = MagicMock()
+    fake_event_type.name = event_name
+
+    fake_evt = MagicMock()
+    fake_evt.assoc = fake_assoc
+    fake_evt._event = fake_event_type
+    return fake_evt
+
+
+def _make_fake_message(event_name="EVT_C_STORE"):
+    """Returns a minimal EventMessage-compatible mock."""
+    from dicomhawk.bus import EventMessage
+    msg = MagicMock(spec=EventMessage)
+    msg.evt = _make_fake_event(event_name=event_name)
+    msg.timestamp = datetime.now()
+    msg.direction = "request"
+    msg.status = None
+    msg.data = None
+    msg.error = None
+    return msg
+
+
+class TestNewHoneypotIdentity:
+    def test_returns_stix_identity(self):
+        identity = new_honeypot_identity()
+        assert isinstance(identity, stix2.Identity)
+
+    def test_identity_class_is_system(self):
+        identity = new_honeypot_identity()
+        assert identity.identity_class == "system"
+
+    def test_identity_name_includes_ae_title(self):
+        identity = new_honeypot_identity(ae_title="MYHONEYPOT")
+        assert "MYHONEYPOT" in identity.name
+
+    def test_identity_has_spec_version(self):
+        identity = new_honeypot_identity()
+        assert identity.spec_version == "2.1"
+
+    def test_identity_id_prefix(self):
+        identity = new_honeypot_identity()
+        assert identity.id.startswith("identity--")
+
+
+class TestToStixBundle:
+    @pytest.fixture
+    def identity(self):
+        return new_honeypot_identity(ae_title="TESTHONEYPOT")
+
+    @pytest.fixture
+    def bundle(self, identity):
+        msg = _make_fake_message("EVT_C_STORE")
+        return to_stix_bundle(msg, identity)
+
+    def test_returns_stix_bundle(self, bundle):
+        assert isinstance(bundle, stix2.Bundle)
+
+    def test_bundle_spec_version(self, bundle):
+        # stix2.Bundle does not expose spec_version as a Python attribute;
+        # verify it instead via the serialized JSON output
+        parsed = json.loads(bundle.serialize())
+        assert parsed["type"] == "bundle"
+
+    def test_bundle_contains_expected_types(self, bundle):
+        types = {obj.type for obj in bundle.objects}
+        assert "ipv4-addr" in types
+        assert "network-traffic" in types
+        assert "attack-pattern" in types
+        assert "observed-data" in types
+        assert "sighting" in types
+        assert "identity" in types
+
+    def test_bundle_has_two_ip_addresses(self, bundle):
+        ips = [o for o in bundle.objects if o.type == "ipv4-addr"]
+        assert len(ips) == 2
+
+    def test_attacker_ip_is_correct(self, bundle):
+        ips = {o.value for o in bundle.objects if o.type == "ipv4-addr"}
+        assert "93.184.216.34" in ips
+
+    def test_honeypot_ip_is_correct(self, bundle):
+        ips = {o.value for o in bundle.objects if o.type == "ipv4-addr"}
+        assert "10.0.0.1" in ips
+
+
+class TestNetworkTraffic:
+    @pytest.fixture
+    def traffic(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        return next(o for o in bundle.objects if o.type == "network-traffic")
+
+    def test_src_port_is_correct(self, traffic):
+        assert traffic.src_port == 52000
+
+    def test_dst_port_is_correct(self, traffic):
+        assert traffic.dst_port == 104
+
+    def test_protocols_includes_tcp(self, traffic):
+        assert "tcp" in traffic.protocols
+
+    def test_src_ref_points_to_ipv4(self, traffic):
+        assert traffic.src_ref.startswith("ipv4-addr--")
+
+    def test_dst_ref_points_to_ipv4(self, traffic):
+        assert traffic.dst_ref.startswith("ipv4-addr--")
+
+
+class TestAttackPattern:
+    @pytest.mark.parametrize("event_name", list(_EVENT_PATTERNS.keys()))
+    def test_all_known_events_produce_attack_pattern(self, event_name):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message(event_name)
+        bundle = to_stix_bundle(msg, identity)
+        patterns = [o for o in bundle.objects if o.type == "attack-pattern"]
+        assert len(patterns) == 1
+
+    @pytest.mark.parametrize("event_name", list(_EVENT_PATTERNS.keys()))
+    def test_attack_pattern_name_matches_mapping(self, event_name):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message(event_name)
+        bundle = to_stix_bundle(msg, identity)
+        pattern = next(o for o in bundle.objects if o.type == "attack-pattern")
+        assert pattern.name == _EVENT_PATTERNS[event_name]["name"]
+
+    def test_attack_pattern_has_dicom_external_reference(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message("EVT_C_FIND")
+        bundle = to_stix_bundle(msg, identity)
+        pattern = next(o for o in bundle.objects if o.type == "attack-pattern")
+        urls = [ref.url for ref in pattern.external_references]
+        assert any("dicomstandard.org" in u for u in urls)
+
+    def test_unknown_event_produces_graceful_fallback(self):
+        """An unrecognized event should not crash the converter."""
+        identity = new_honeypot_identity()
+        msg = _make_fake_message("EVT_UNKNOWN_EVENT_XYZ")
+        bundle = to_stix_bundle(msg, identity)
+        patterns = [o for o in bundle.objects if o.type == "attack-pattern"]
+        assert len(patterns) == 1
+        assert "EVT_UNKNOWN_EVENT_XYZ" in patterns[0].name
+
+
+class TestObservedData:
+    @pytest.fixture
+    def identity(self):
+        return new_honeypot_identity()
+
+    @pytest.fixture
+    def observed(self, identity):
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        return next(o for o in bundle.objects if o.type == "observed-data")
+
+    def test_number_observed_is_one(self, observed):
+        assert observed.number_observed == 1
+
+    def test_first_and_last_observed_match(self, observed):
+        assert observed.first_observed == observed.last_observed
+
+    def test_object_refs_includes_network_traffic(self, identity):
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        observed = next(o for o in bundle.objects if o.type == "observed-data")
+        traffic = next(o for o in bundle.objects if o.type == "network-traffic")
+        assert traffic.id in observed.object_refs
+
+    def test_timestamp_is_utc_aware(self, observed):
+        assert observed.first_observed.tzinfo is not None
+
+
+class TestSighting:
+    @pytest.fixture
+    def bundle(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message("EVT_C_GET")
+        return to_stix_bundle(msg, identity), identity
+
+    def test_sighting_exists(self, bundle):
+        b, _ = bundle
+        sightings = [o for o in b.objects if o.type == "sighting"]
+        assert len(sightings) == 1
+
+    def test_sighting_of_ref_points_to_attack_pattern(self, bundle):
+        b, _ = bundle
+        sighting = next(o for o in b.objects if o.type == "sighting")
+        attack = next(o for o in b.objects if o.type == "attack-pattern")
+        assert sighting.sighting_of_ref == attack.id
+
+    def test_sighting_observed_data_refs_match(self, bundle):
+        b, _ = bundle
+        sighting = next(o for o in b.objects if o.type == "sighting")
+        observed = next(o for o in b.objects if o.type == "observed-data")
+        assert observed.id in sighting.observed_data_refs
+
+    def test_sighting_where_sighted_refs_is_honeypot(self, bundle):
+        b, identity = bundle
+        sighting = next(o for o in b.objects if o.type == "sighting")
+        assert identity.id in sighting.where_sighted_refs
+
+    def test_sighting_count_is_one(self, bundle):
+        b, _ = bundle
+        sighting = next(o for o in b.objects if o.type == "sighting")
+        assert sighting.count == 1
+
+
+class TestSerialization:
+    def test_bundle_serializes_to_valid_json(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        parsed = json.loads(bundle.serialize())
+        assert parsed["type"] == "bundle"
+        assert len(parsed["objects"]) > 0
+
+    def test_all_objects_have_stix_ids(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        for obj in bundle.objects:
+            assert obj.id, f"Object {obj.type} has no id"
+
+    def test_all_sdos_have_created_by_ref(self):
+        identity = new_honeypot_identity()
+        msg = _make_fake_message()
+        bundle = to_stix_bundle(msg, identity)
+        sdos = [o for o in bundle.objects if o.type in {
+            "attack-pattern", "observed-data", "sighting"
+        }]
+        for sdo in sdos:
+            assert sdo.created_by_ref == identity.id, (
+                f"{sdo.type} missing created_by_ref"
+            )


### PR DESCRIPTION
## What this does

Hi @RicYaben, as per our discussion in #126 I went ahead and mapped every `EventMessage` the bus emits to a STIX 2.1 Bundle and wrote it to a rotating NDJSON file. Activate it with `--stix-out <dir>` on the serve command, nothing changes if you don't pass the flag.

## What I changed

- **`src/dicomhawk/stix.py`** (new) — kept this as a pure converter with no side effects. `new_honeypot_identity()` creates the honeypot's Identity SDO once at startup, `to_stix_bundle()` does the actual conversion, and `StixHandler` is a small `logging.Handler` subclass that intercepts `EventMessage` records from the bus and writes the serialised bundle to disk via a `RotatingFileHandler`.

- **`src/dicomhawk/bus.py`** — added two optional kwargs to `new_bus()` (`stix_out` and `stix_identity`). Nothing breaks if you don't pass them.

- **`src/commands/serve.py`** — wired up the `--stix-out` flag. If it's set, the Identity SDO gets created using the existing `ae_title` and `impl_uid` args and passed into the bus.

- **`pyproject.toml`** — added `stix2>=3.0.0` as an optional extra (`pip install dicomhawk[stix]`). Also added it to `dev` so the tests just work.

## STIX object graph per event

Each event turns into a Bundle with 7 objects:

- `IPv4Address` (attacker) + `IPv4Address` (honeypot) → `NetworkTraffic`
- `NetworkTraffic` + both IPs → `ObservedData`
- `AttackPattern` (DICOM operation classification) → `Sighting`
- `Sighting` ties it all together: what was observed, what attack it classifies as, and where (our honeypot identity)

I mapped all 7 event types: `EVT_C_STORE`, `EVT_C_FIND`, `EVT_C_GET`,`EVT_C_MOVE`, `EVT_ACSE_RECV`, `EVT_RELEASED`, `EVT_ABORTED`. Unknown event names fall back gracefully instead of crashing.

## Two design choices that I want to discuss

**`Sighting` instead of `Relationship`** — I went with `Sighting` because it felt like the right semantic fit for honeypot data. It has `where_sighted_refs` for our identity, `observed_data_refs` for the raw network observables, and a `count`, so the bundles plug straight into MISP or OpenCTI without extra wrangling. That said, a plain `Relationship` keeps the graph simpler if you'd prefer that.

**Optional dep** — put `stix2` behind an optional extra to keep the default install clean, but I'm on the fence given this is a dedicated feature branch. Happy to move it to core if that makes more sense.

## Tests

I added tests/test_stix.py — the v3.0 codebase doesn't have any tests yet, so I wasn't sure what style you'd want, but shipping this without any coverage felt wrong. It hits all 7 event types, the object graph references, UTC timestamp handling, serialisation, and the unknown-event fallback. 44 assertions, all passing.

```bash
pip install 'dicomhawk[dev]'
pytest tests/test_stix.py -v
```

If the tests don't fit the direction you have in mind for the project, just say the word and I'll remove them. Please have a look and let me know if any changes are required.
