### PR TITLE
fix: resolve silent startup failure and log directory creation crash

### DIFF
--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -6,6 +6,3 @@ app.add_typer(serve_app)
 
 def main():
     app()
-
-if __name__ == "__main__":
-    main()

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -6,3 +6,6 @@ app.add_typer(serve_app)
 
 def main():
     app()
+
+if __name__ == "__main__":
+    main()

--- a/src/dicomhawk/bus.py
+++ b/src/dicomhawk/bus.py
@@ -83,8 +83,8 @@ def new_bus(stdout: Optional[str] = None, when: Optional[str] = None, interval: 
     if not stdout:
         return lg
     
-    # create the file if it does not exist
-    Path(stdout).mkdir(parents=True, exist_ok=True)
+    # create the directory if it does not exist
+    Path(stdout).parent.mkdir(parents=True, exist_ok=True)
     
     if when:
         lg = config_bus_time_rotation(lg, stdout, when, interval)


### PR DESCRIPTION
Hey @RicYaben,

As you suggested, I removed the bug fixes from the profiles PR and opened this separate one for them.

This PR fixes two small issues I ran into while testing:
1. main.py: The CLI was silently exiting because main() wasn't being called. Added the standard `__name__ == "__main__"` guard so `dicomhawk serve` actually starts.
2. bus.py: Logging was crashing if the data/ folder didn't exist. Fixed it by creating the parent directory before opening the log file.

These were pretty straightforward blockers. Please let me know if this approach looks good or if you'd rather have them done differently. Happy to change anything.