### PR TITLE
fix: pin all dependency versions in dicom_server/requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,31 +13,31 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "pydicom",
-    "pynetdicom",
-    "pylibjpeg",
-    "pylibjpeg-libjpeg",
-    "pylibjpeg-openjpeg",
-    "requests",
-    "redis",
-    "schedule",
-    "jwt",
-    "dependency-injector",
-    "aenum",
-    "pytz",
-    "overpy",
-    "sqlalchemy",
-    "typer", 
-    "numpy",
+    "pydicom==3.0.2",
+    "pynetdicom==3.0.4",
+    "pylibjpeg==2.1.0",
+    "pylibjpeg-libjpeg==2.4.0",
+    "pylibjpeg-openjpeg==2.5.0",
+    "requests==2.33.1",
+    "redis==7.4.0",
+    "schedule==1.2.2",
+    "jwt==1.4.0",
+    "dependency-injector==4.49.0",
+    "aenum==3.1.17",
+    "pytz==2026.1.post1",
+    "overpy==0.7",
+    "sqlalchemy==2.0.48",
+    "typer==0.24.1",
+    "numpy==2.4.4",
     # for the web
-    "flask",
-    "ujson"
+    "flask==3.1.3",
+    "ujson==5.12.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "faker",
+    "pytest==9.0.2",
+    "faker==40.12.0",
 ]
 
 [tool.setuptools]

--- a/tests/test_dependencies_pinned.py
+++ b/tests/test_dependencies_pinned.py
@@ -1,0 +1,43 @@
+"""
+Tests that all packages in pyproject.toml are pinned to exact versions.
+
+Unpinned dependencies make deployments non-reproducible: a fresh
+pip install may pull incompatible versions and break the application.
+Every dependency must use == to pin an exact version.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+
+PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+
+
+def load_all_deps():
+    with open(PYPROJECT, "rb") as fh:
+        data = tomllib.load(fh)
+    project = data.get("project", {})
+    deps = project.get("dependencies", [])
+    dev_deps = []
+    for group in project.get("optional-dependencies", {}).values():
+        dev_deps.extend(group)
+    return deps, dev_deps
+
+
+class TestDependenciesPinned:
+    def test_main_deps_pinned_with_exact_version(self):
+        deps, _ = load_all_deps()
+        unpinned = [d for d in deps if not re.search(r"==", d)]
+        assert not unpinned, (
+            "The following packages in [project.dependencies] are not pinned with ==:\n"
+            + "\n".join(unpinned)
+        )
+
+    def test_dev_deps_pinned_with_exact_version(self):
+        _, dev_deps = load_all_deps()
+        unpinned = [d for d in dev_deps if not re.search(r"==", d)]
+        assert not unpinned, (
+            "The following packages in [project.optional-dependencies] are not pinned with ==:\n"
+            + "\n".join(unpinned)
+        )


### PR DESCRIPTION
Fixes #148.

## What

All 20 packages in `pyproject.toml` had no version pins. A fresh `pip install` could pull incompatible versions at any point in the future and silently break the application.

## Fix

Pinned all packages to the versions resolved by installing the full list in a clean Python 3.12 virtual environment (matching the Dockerfile base image).

| Package | Before | After |
|---|---|---|
| pydicom | unpinned | `==3.0.2` |
| pynetdicom | unpinned | `==3.0.4` |
| pylibjpeg | unpinned | `==2.1.0` |
| pylibjpeg-libjpeg | unpinned | `==2.4.0` |
| pylibjpeg-openjpeg | unpinned | `==2.5.0` |
| requests | unpinned | `==2.33.1` |
| redis | unpinned | `==7.4.0` |
| schedule | unpinned | `==1.2.2` |
| jwt | unpinned | `==1.4.0` |
| dependency-injector | unpinned | `==4.49.0` |
| aenum | unpinned | `==3.1.17` |
| pytz | unpinned | `==2026.1.post1` |
| overpy | unpinned | `==0.7` |
| sqlalchemy | unpinned | `==2.0.48` |
| typer | unpinned | `==0.24.1` |
| numpy | unpinned | `==2.4.4` |
| flask | unpinned | `==3.1.3` |
| ujson | unpinned | `==5.12.0` |
| pytest | unpinned | `==9.0.2` |
| faker | unpinned | `==40.12.0` |

## Tests

Added `tests/test_dependencies_pinned.py`. It reads `pyproject.toml` with `tomllib` (stdlib since Python 3.11) and checks that every entry in `[project.dependencies]` and `[project.optional-dependencies]` uses `==`. Both tests fail before this fix and pass after.