### PR TITLE
fix: run containers as non-root user in all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,9 @@ COPY src/ src/
 
 RUN pip install .
 
+RUN adduser --disabled-password --gecos "" dicomhawk && \
+    chown -R dicomhawk:dicomhawk /app
+
+USER dicomhawk
+
 CMD ["dicomhawk", "serve"]

--- a/tests/test_dockerfile_non_root.py
+++ b/tests/test_dockerfile_non_root.py
@@ -1,0 +1,57 @@
+"""
+Tests that the Dockerfile switches to a non-root user before CMD.
+
+Running a container as root raises the attack surface. A dedicated
+non-root USER directive must appear after all RUN/COPY/ADD steps that
+need root privileges.
+"""
+
+import re
+from pathlib import Path
+
+
+DOCKERFILE = Path(__file__).parent.parent / "Dockerfile"
+
+
+def read_lines():
+    with open(DOCKERFILE) as fh:
+        return [line.rstrip() for line in fh]
+
+
+def last_user_value(lines):
+    value = None
+    for line in lines:
+        m = re.match(r"^\s*USER\s+(\S+)", line, re.IGNORECASE)
+        if m:
+            value = m.group(1)
+    return value
+
+
+class TestDockerfileNonRoot:
+    def test_has_non_root_user_directive(self):
+        lines = read_lines()
+        user = last_user_value(lines)
+        assert user is not None, (
+            "Dockerfile has no USER directive. Add a non-root USER before CMD."
+        )
+        assert user.lower() != "root" and user != "0", (
+            f"Last USER directive is {user!r}. Use a dedicated non-root user."
+        )
+
+    def test_user_comes_after_install_steps(self):
+        lines = read_lines()
+        last_user_idx = None
+        last_privileged_idx = None
+        for i, line in enumerate(lines):
+            if re.match(r"^\s*USER\s+", line, re.IGNORECASE):
+                last_user_idx = i
+            if re.match(r"^\s*(RUN|COPY|ADD)\s+", line, re.IGNORECASE):
+                last_privileged_idx = i
+
+        assert last_user_idx is not None, "Dockerfile has no USER directive."
+        assert last_privileged_idx is not None, "Dockerfile has no RUN/COPY/ADD."
+        assert last_user_idx > last_privileged_idx, (
+            f"USER (line {last_user_idx + 1}) appears before the last "
+            f"RUN/COPY/ADD (line {last_privileged_idx + 1}). "
+            "Move USER after all install and copy steps."
+        )


### PR DESCRIPTION
Fixes #149.

## What

The Dockerfile runs the application process as root. A container escape
or RCE vulnerability would give an attacker root on the host.

## Fix

After all package installs and file copies are complete:

1. Create a dedicated `dicomhawk` user.
2. `chown` the application working directory to `dicomhawk`.
3. `USER dicomhawk` before `CMD`.

**Files changed:**
- `Dockerfile`

## Tests

Added `tests/test_dockerfile_non_root.py`. It checks:

1. A non-root `USER` directive exists (not `root` or `0`).
2. The `USER` directive appears after the last `RUN`/`COPY`/`ADD` instruction.

Both tests fail before this fix and pass after.