### PR TITLE
fixed: `handels()`

### DIFF
--- a/dicom_server/core/dicom_handlers.py
+++ b/dicom_server/core/dicom_handlers.py
@@ -207,11 +207,11 @@ class DICOMHandlers:
         self, event
     ) -> Generator[Tuple[int, Optional[Dataset]], None, None]:
 
+        assoc = event.assoc
+        identifier = event.identifier
         addr = assoc.requestor.address
         port = assoc.requestor.port
         yield (str(addr), port)
-        assoc = event.assoc
-        identifier = event.identifier
 
         if dicom_util.identifier_invalid(identifier):
             yield 0xC000, None


### PR DESCRIPTION
fixes:  #143 

made 
```python
  self, event
    ) -> Generator[Tuple[int, Optional[Dataset]], None, None]:

        assoc = event.assoc
        identifier = event.identifier
        addr = assoc.requestor.address
        port = assoc.requestor.port
        yield (str(addr), port)
```

now the `assoc` is used after the declaration  

test cases pass locally
<img width="1753" height="98" alt="Screenshot 2026-03-31 134221" src="https://github.com/user-attachments/assets/3fbf9a11-b616-4ce2-a3e8-b0a62db178cd" />