### PR TITLE
Storage jail quarantined uploads excluded from DICOM responses

### DIFF
--- a/src/dicomhawk/repository.py
+++ b/src/dicomhawk/repository.py
@@ -116,6 +116,9 @@ class Repository:
             conn.rollback()
             return QRResult(error=QRError(f"Exception occurred while querying database: {exc}"))
 
+        # Quarantine jail: uploaded files must never be visible to DICOM clients.
+        matches = [m for m in matches if not self.storage.is_quarantined(m.filename)]
+
         if inject:
             matches = [self._apply_middlewares(m) for m in matches]
 
@@ -165,6 +168,9 @@ class Repository:
             logger.exception(exc)
 
     def find_instance(self, match: Dataset, decompress: bool = False, inject: bool = True) -> FindResult:
+        if self.storage.is_quarantined(match.filename):
+            return FindResult(error=QRError(f"Refusing to serve quarantined instance: {match.filename}", QRStatus.STORE_ERROR))
+
         try:
             instance = dcmread(match.filename)
         except Exception as exc:

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -57,6 +57,14 @@ class Storage:
         
         return full
 
+    def is_quarantined(self, path: str) -> bool:
+        """Return True if path is inside the quarantine directory."""
+        try:
+            Path(path).resolve().relative_to(self.quarantine_dir.resolve())
+            return True
+        except ValueError:
+            return False
+
     def path_for(self, safe: bool, filename: str) -> Path:
         """
         Get a jailed path for the given filename.


### PR DESCRIPTION
Closes #159 

- Verified store() routes C-STORE uploads to traces/quarantine/ 
- Added is_quarantined() to Storage
- find() post-filters db.search() results to exclude quarantined instances from C-FIND