### PR TITLE
Add TCIA seed command Implements #163

### DIFF
--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -1,10 +1,13 @@
 import typer
-from .serve import serve_app
+
 from .component import component_app
+from .seed import seed_app
+from .serve import serve_app
 
 app = typer.Typer(help="DicomHawk")
 app.add_typer(serve_app)
 app.add_typer(component_app)
+app.add_typer(seed_app)
 
 def main():
     app()

--- a/src/commands/seed.py
+++ b/src/commands/seed.py
@@ -1,0 +1,52 @@
+import typer
+
+from dicomhawk.repository import new_repo
+from dicomhawk.seeder import new_seeder
+from dicomhawk.storage import new_store
+
+seed_app = typer.Typer(help="Seed the honeypot database with realistic DICOM data from TCIA")
+
+
+@seed_app.command()
+def seed(
+    collection: str = typer.Option(
+        "TCGA-LUAD",
+        "-c",
+        "--collection",
+        help="TCIA collection name to pull from (see cancerimagingarchive.net)",
+    ),
+    max_series: int = typer.Option(
+        3,
+        "-s",
+        "--max-series",
+        help="Maximum number of series to download from the collection",
+    ),
+    max_images: int = typer.Option(
+        5,
+        "-n",
+        "--max-images",
+        help="Maximum number of images to ingest per series",
+    ),
+    database: str | None = typer.Option(
+        None,
+        "-db",
+        "--database",
+        help="Path to the SQLite database (must match the path used by dicomhawk serve)",
+    ),
+    traces: str = typer.Option(
+        "traces",
+        "-t",
+        "--traces",
+        help="Traces directory (must match the path used by dicomhawk serve)",
+    ),
+):
+    store = new_store(traces)
+    repo = new_repo(database, store, [])
+    repo.start()
+
+    try:
+        seeder = new_seeder(repo)
+        n = seeder.seed(collection, max_series, max_images)
+        typer.echo(f"Seeded {n} instances from '{collection}'")
+    finally:
+        repo.stop()

--- a/src/dicomhawk/repository.py
+++ b/src/dicomhawk/repository.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from pydicom import dcmread
 from pydicom.uid import UID
@@ -58,6 +59,8 @@ class Repository:
         kwargs: dict = {"connect_args": {"check_same_thread": False}}
         if self.location == ":memory:":
             kwargs["poolclass"] = StaticPool
+        else:
+            Path(self.location).parent.mkdir(parents=True, exist_ok=True)
         engine = create_engine(url, **kwargs)
         db.Base.metadata.create_all(engine)
         meta = MetaData()

--- a/src/dicomhawk/seeder.py
+++ b/src/dicomhawk/seeder.py
@@ -1,0 +1,213 @@
+import io
+import logging
+import random
+from dataclasses import dataclass
+from hashlib import md5
+
+import requests
+from pydicom import dcmread
+from pydicom.dataset import Dataset
+
+from .repository import Repository
+
+logger = logging.getLogger(__name__)
+
+_NBIA_BASE = "https://services.cancerimagingarchive.net/nbia-api/services/v1"
+
+
+@dataclass(frozen=True)
+class Location:
+    institution: str
+    address: str
+    physicians: tuple[str, ...]
+    patients: tuple[str, ...]
+
+
+_LOCATIONS: list[Location] = [
+    Location(
+        "Valley Medical Center",
+        "1400 West Valley Pkwy, Escondido, CA 92029",
+        ("Rivera^Carlos^M", "Patel^Anita^K", "Thompson^David^R"),
+        (
+            "Anderson^James^T", "Brown^Patricia^L", "Clark^Michael^S",
+            "Davis^Linda^J", "Evans^Robert^W", "Foster^Barbara^A",
+        ),
+    ),
+    Location(
+        "Riverside General Hospital",
+        "9851 Magnolia Ave, Riverside, CA 92503",
+        ("Nguyen^Thuy^H", "Kim^James^Y", "Okonkwo^Emeka^C"),
+        (
+            "Garcia^Maria^E", "Harris^Charles^B", "Jackson^Dorothy^M",
+            "Johnson^William^F", "Lewis^Ruth^A", "Martin^Joseph^D",
+        ),
+    ),
+    Location(
+        "Lakewood Community Hospital",
+        "3700 E South St, Lakewood, CA 90712",
+        ("Chen^Wei^L", "Sharma^Priya^N", "Robinson^Mark^A"),
+        (
+            "Moore^Thomas^H", "Nelson^Sandra^K", "Parker^Kevin^R",
+            "Roberts^Karen^S", "Scott^George^E", "Turner^Nancy^C",
+        ),
+    ),
+    Location(
+        "Northgate Regional Medical",
+        "5555 N Gate Blvd, Sacramento, CA 95834",
+        ("Williams^Janet^M", "Jones^Brian^T", "Martinez^Elena^R"),
+        (
+            "Walker^Steven^L", "White^Deborah^J", "Young^Edward^P",
+            "Adams^Carol^W", "Baker^Frank^N", "Campbell^Shirley^B",
+        ),
+    ),
+    Location(
+        "Desert Springs Medical Center",
+        "2075 E Flamingo Rd, Las Vegas, NV 89119",
+        ("Taylor^Michael^D", "Wilson^Sarah^A", "Lee^Kevin^J"),
+        (
+            "Collins^Harold^K", "Edwards^Gloria^T", "Flores^Miguel^A",
+            "Green^Helen^R", "Hall^Dennis^S", "Hill^Margaret^L",
+        ),
+    ),
+    Location(
+        "Summit View Hospital",
+        "800 Summit Ridge Dr, Denver, CO 80203",
+        ("Patel^Raj^S", "O'Brien^Katherine^M", "Yamamoto^Kenji^T"),
+        (
+            "Jenkins^Arthur^G", "King^Virginia^L", "Lee^Raymond^C",
+            "Mitchell^Donna^H", "Perry^Billy^J", "Reed^Alice^F",
+        ),
+    ),
+]
+
+_SENSITIVITY_TAGS = (
+    "PatientBirthDate",
+    "PatientAddress",
+    "PatientTelephoneNumbers",
+    "OtherPatientIDs",
+    "OtherPatientNames",
+    "PatientMotherBirthName",
+    "ResponsiblePerson",
+)
+
+
+def _stable_pick(pool: tuple[str, ...], key: str) -> str:
+    idx = int(md5(key.encode()).hexdigest(), 16) % len(pool)
+    return pool[idx]
+
+
+def _patch_location(ds: Dataset, loc: Location) -> Dataset:
+    patient_key = str(getattr(ds, "PatientID", "") or getattr(ds, "PatientName", "") or "")
+    study_key = str(getattr(ds, "StudyInstanceUID", patient_key) or patient_key)
+
+    ds.InstitutionName = loc.institution
+    ds.InstitutionAddress = loc.address
+    ds.StationName = f"{getattr(ds, 'Modality', 'XX')}01"
+    ds.PatientName = _stable_pick(loc.patients, patient_key)
+    ds.PatientID = md5(patient_key.encode()).hexdigest()[:8].upper()
+    ds.ReferringPhysicianName = _stable_pick(loc.physicians, study_key)
+
+    for tag in _SENSITIVITY_TAGS:
+        if hasattr(ds, tag):
+            try:
+                delattr(ds, tag)
+            except AttributeError:
+                pass
+
+    return ds
+
+
+class TciaClient:
+    def __init__(self, base_url: str = _NBIA_BASE, timeout: int = 30):
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def get_series(self, collection: str, modality: str = "CT") -> list[dict]:
+        try:
+            r = requests.get(
+                f"{self._base}/getSeries",
+                params={"Collection": collection, "Modality": modality},
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            return r.json()
+        except (requests.RequestException, ValueError) as exc:
+            logger.error(f"TCIA getSeries failed: {exc}")
+            return []
+
+    def get_sop_uids(self, series_uid: str) -> list[str]:
+        try:
+            r = requests.get(
+                f"{self._base}/getSOPInstanceUIDs",
+                params={"SeriesInstanceUID": series_uid},
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            items = r.json()
+        except (requests.RequestException, ValueError) as exc:
+            logger.error(f"TCIA getSOPInstanceUIDs failed for {series_uid}: {exc}")
+            return []
+        return [uid for item in items if (uid := item.get("SOPInstanceUID"))]
+
+    def download_image(self, series_uid: str, sop_uid: str) -> bytes | None:
+        try:
+            r = requests.get(
+                f"{self._base}/getSingleImage",
+                params={"SeriesInstanceUID": series_uid, "SOPInstanceUID": sop_uid},
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            return r.content
+        except requests.RequestException as exc:
+            logger.error(f"TCIA getSingleImage failed for {sop_uid}: {exc}")
+            return None
+
+
+class Seeder:
+    def __init__(self, repo: Repository):
+        self._repo = repo
+        self._client = TciaClient()
+
+    def seed(self, collection: str, max_series: int = 3, max_images: int = 5) -> int:
+        loc = random.choice(_LOCATIONS)
+        series_list = self._client.get_series(collection)
+        if not series_list:
+            logger.warning(f"TCIA unreachable or no CT series in '{collection}'; nothing seeded")
+            return 0
+
+        # prefer smaller series to keep seeding fast
+        series_list.sort(key=lambda s: int(s.get("NumberOfSeriesRelatedInstances", 999)))
+
+        stored = 0
+        for entry in series_list[:max_series]:
+            if uid := entry.get("SeriesInstanceUID"):
+                stored += self._ingest_series(uid, loc, max_images)
+
+        logger.info(f"Seeded {stored} instances from '{collection}' as '{loc.institution}'")
+        return stored
+
+    def _ingest_series(self, series_uid: str, loc: Location, max_images: int) -> int:
+        sop_uids = self._client.get_sop_uids(series_uid)
+
+        stored = 0
+        for sop_uid in sop_uids[:max_images]:
+            data = self._client.download_image(series_uid, sop_uid)
+            if data is None:
+                continue
+            try:
+                ds = dcmread(io.BytesIO(data))
+            except Exception as exc:
+                logger.error(f"Error reading {sop_uid}: {exc}")
+                continue
+            ds = _patch_location(ds, loc)
+            err = self._repo.store(ds, safe=True)
+            if err is None:
+                stored += 1
+            else:
+                logger.warning(f"Failed to store {sop_uid}: {err.error}")
+
+        return stored
+
+
+def new_seeder(repo: Repository) -> Seeder:
+    return Seeder(repo)


### PR DESCRIPTION
- Adds a seed subcommand to cli
- Pulls CT series dynamically from the TCIA API 
- Ingests downloaded instances as queryable data
- Patches location metadata from a pool of synthetic locations
