### PR TITLE
OSM, Faker seeding and DICOM query fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ DICOMHAWK_AE_TITLE=ORTHANC
 # Comma-separated list of ports the honeypot listens on inside the container.
 # The host-side publishing in docker-compose.yml must map onto these.
 DICOMHAWK_PORTS=104,11112
+
+# SQLite path inside the container (on the storage volume, so `seed` and the server share it).
+# Leave empty for an in-memory DB, which can't be seeded.
+DICOMHAWK_DB=/opt/dicomhawk/storage/dicomhawk.db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: dicomhawk:latest
     container_name: dicomhawk
     restart: unless-stopped
+    tty: true   # pseudo-TTY so the server's stdout is a terminal → colored `docker logs`
     env_file:
       - .env
     ports:
@@ -16,10 +17,13 @@ services:
       - "${DICOMHAWK_PORTS:-104,11112}"
       - -ae
       - "${DICOMHAWK_AE_TITLE:-ORTHANC}"
+      - -db
+      - "${DICOMHAWK_DB:-/opt/dicomhawk/storage/dicomhawk.db}"
       - -t
       - /opt/dicomhawk/storage
       - -l
       - /var/log/dicomhawk/dicomhawk.log
+      - -v
     volumes:
       - dicom_storage:/opt/dicomhawk/storage
       - logs:/var/log/dicomhawk

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,51 @@
+# Commands
+
+## `dicomhawk serve`
+
+Start the DICOM honeypot server.
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--host` | `-h` | `0.0.0.0` | Bind address |
+| `--ports` | `-p` | `104,11112` | Comma-separated listen ports |
+| `--ae_title` | `-ae` | `ORTHANC` | AE title advertised to peers |
+| `--impl_uid` | `-uid` | `1.2.3.4` | Implementation class UID |
+| `--impl_name` | `-name` | `ORTHANC` | Implementation version name |
+| `--dimse` | `-d` | `associate,echo,get,find,move,store,release,abort` | Enabled DIMSE operations (comma-separated) |
+| `--database` | `-db` | *(in-memory)* | Path to SQLite database file — **must match `seed --database`** |
+| `--traces` | `-t` | `traces` | Directory for received DICOM files and quarantined uploads |
+| `--log-path` | `-l` | `data/dicomhawk.log` | JSON interaction event log (one record per line) |
+| `--honey-url` | | | URL injected as `RetrieveURL` in outbound datasets |
+| `--canary-pdf` | | | Path to a PDF canary token injected as `EncapsulatedDocument` |
+| `--dev-log` | | | Path for Python-level warnings, errors, and pynetdicom protocol events |
+| `--verbose` | `-v` | | Print a compact colored event summary to stdout; auto-enabled when stdout is a TTY |
+
+**Note:** with the default in-memory database, seeded data does not persist between restarts. Pass `--database` for any deployment intended to survive a restart.
+
+---
+
+## `dicomhawk seed`
+
+Populate the honeypot database with realistic DICOM data from [TCIA](https://www.cancerimagingarchive.net/).
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--collection` | `-c` | `TCGA-LUAD` | TCIA collection name |
+| `--max-series` | `-s` | `3` | Max series to download |
+| `--max-images` | `-n` | `5` | Max images per series |
+| `--database` | `-db` | *(in-memory)* | SQLite database path — **must match `serve --database`** |
+| `--traces` | `-t` | `traces` | Traces directory — **must match `serve --traces`** |
+| `--locations` | `-L` | *(built-in)* | JSON file of `[{"institution": "...", "address": "..."}]` |
+| `--locale` | | `en_US` | Faker locale for patient/physician name generation (e.g. `de_DE`, `ja_JP`) |
+| `--modality` | `-m` | `CT` | DICOM modality to request from TCIA (e.g. `CT`, `MR`, `US`, `DX`) |
+| `--osm-city` | | | Query OpenStreetMap for real hospital names in this city |
+| `--osm-country` | | | ISO 3166-1 alpha-2 country code for OSM query (e.g. `US`, `DE`) |
+| `--osm-cache` | | `~/.cache/dicomhawk/osm.json` | Path for the OSM institution cache (TTL: 24 h) |
+| `--osm-max` | | `50` | Maximum number of institutions to fetch from OpenStreetMap |
+| `--interval` | `-i` | `0` | Re-seed every N minutes in the background; `0` = run once and exit |
+
+**Location resolution order:** OSM query → `--locations` file → built-in 6-entry defaults. Each level falls back to the next if it returns nothing or fails.
+
+**OSM scoping:** pair `--osm-city` with `--osm-country` — the city alone matches same-named cities in every country (there is more than one "Berlin"), and the country code pins it to the one you mean. Up to `--osm-max` names are kept; results are cached for 24 h per city/country pair.
+
+**TCIA fallback:** if TCIA is unreachable the command logs a warning and exits with 0 instances stored. With `--interval` it retries on the next tick automatically.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,10 +46,12 @@ docker compose ps          # status should turn `healthy` within ~30 seconds
 docker compose logs -f dicomhawk
 ```
 
-Compose maps:
+Compose publishes:
 
-- container port `11112` → host `${DICOMHAWK_PORT_PRIMARY:-11112}`
-- container port `104` → host `${DICOMHAWK_PORT_SECONDARY:-1104}` (the host side defaults to a non-privileged port to avoid needing `CAP_NET_BIND_SERVICE`)
+- container port `11112` → host `11112`
+- container port `104` → host `1104` (non-privileged default; avoids `CAP_NET_BIND_SERVICE`)
+
+`DICOMHAWK_PORTS` in `.env` controls which ports the server process listens on *inside* the container. The host-side publishing above is fixed in `docker-compose.yml`; edit it directly if you need different host ports.
 
 To stop and clean up:
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -49,6 +49,54 @@ A successful C-STORE produces:
 - a `.dcm` file under `./traces/storage/`
 - a JSON line in `./data/dicomhawk.log` describing the request and the SCP response
 
+## Seed the database
+
+Before starting the server, populate it with realistic DICOM data from [TCIA](https://www.cancerimagingarchive.net/). The `--database` and `--traces` paths **must match** the values you pass to `dicomhawk serve`.
+
+```bash
+# one-shot seed from TCGA-LUAD (requires internet)
+dicomhawk seed \
+    --database ./data/dicomhawk.db \
+    --traces ./traces
+
+# start the server against the seeded database
+dicomhawk serve \
+    -p 11112 -ae ORTHANC \
+    --database ./data/dicomhawk.db \
+    -t ./traces \
+    -l ./data/dicomhawk.log
+```
+
+Seed with real hospital names from OpenStreetMap (falls back to built-in list if Overpass is unreachable). Pass `--osm-country` alongside `--osm-city` so the city resolves to the right country:
+
+```bash
+dicomhawk seed --database ./data/dicomhawk.db --traces ./traces \
+    --osm-city "Boston" --osm-country "US"
+```
+
+Re-seed automatically every 60 minutes (blocks until Ctrl-C or SIGTERM):
+
+```bash
+dicomhawk seed --database ./data/dicomhawk.db --traces ./traces \
+    --interval 60
+```
+
+Generate patient/physician names in a different locale:
+
+```bash
+dicomhawk seed --database ./data/dicomhawk.db --traces ./traces \
+    --locale de_DE
+```
+
+Provide your own location list (`[{"institution": "...", "address": "..."}]`):
+
+```bash
+dicomhawk seed --database ./data/dicomhawk.db --traces ./traces \
+    --locations ./my-locations.json
+```
+
+If TCIA is unreachable the command logs a warning and exits cleanly with 0 instances stored. With `--interval` it retries automatically on the next tick.
+
 ## Where to look
 
 | What | venv | Docker |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ dependencies = [
     "numpy",
     # for the web
     "flask",
-    "ujson"
+    "ujson",
+    "faker",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "faker",
 ]
 
 [tool.setuptools]

--- a/src/commands/seed.py
+++ b/src/commands/seed.py
@@ -1,7 +1,8 @@
+import signal
 import typer
 
 from dicomhawk.repository import new_repo
-from dicomhawk.seeder import new_seeder
+from dicomhawk.seeder import OsmClient, SeedScheduler, load_locations, new_seeder
 from dicomhawk.storage import new_store
 
 seed_app = typer.Typer(help="Seed the honeypot database with realistic DICOM data from TCIA")
@@ -39,14 +40,85 @@ def seed(
         "--traces",
         help="Traces directory (must match the path used by dicomhawk serve)",
     ),
+    locations: str | None = typer.Option(
+        None,
+        "-L",
+        "--locations",
+        help='Path to a JSON file of locations: [{"institution": "...", "address": "..."}]',
+    ),
+    locale: str = typer.Option(
+        "en_US",
+        "--locale",
+        help="Faker locale for patient and physician name generation (e.g. en_US, de_DE, ja_JP)",
+    ),
+    osm_city: str | None = typer.Option(
+        None,
+        "--osm-city",
+        help="City name to query OpenStreetMap for real hospital names (e.g. 'New York')",
+    ),
+    osm_country: str | None = typer.Option(
+        None,
+        "--osm-country",
+        help="ISO 3166-1 alpha-2 country code to query OpenStreetMap (e.g. 'US', 'DE')",
+    ),
+    osm_cache: str | None = typer.Option(
+        None,
+        "--osm-cache",
+        help="Path for the OSM institution cache file (default: ~/.cache/dicomhawk/osm.json)",
+    ),
+    osm_max: int = typer.Option(
+        50,
+        "--osm-max",
+        help="Maximum number of institutions to fetch from OpenStreetMap",
+    ),
+    modality: str = typer.Option(
+        "CT",
+        "-m",
+        "--modality",
+        help="DICOM modality to request from TCIA (e.g. CT, MR, US, DX)",
+    ),
+    interval: int = typer.Option(
+        0,
+        "-i",
+        "--interval",
+        help="Re-seed every N minutes in the background (0 = run once and exit)",
+    ),
 ):
+    # Resolve location list: OSM > --locations file > built-in defaults
+    if osm_city or osm_country:
+        osm = OsmClient(city=osm_city, country=osm_country, cache_path=osm_cache, max_results=osm_max)
+        osm_locs = osm.get_locations()
+        if osm_locs:
+            typer.echo(f"Fetched {len(osm_locs)} institutions from OpenStreetMap")
+        else:
+            typer.echo("OpenStreetMap returned no institutions; using built-in defaults")
+        loc_list = osm_locs or load_locations(locations)
+    else:
+        loc_list = load_locations(locations)
+
     store = new_store(traces)
     repo = new_repo(database, store, [])
     repo.start()
 
     try:
-        seeder = new_seeder(repo)
-        n = seeder.seed(collection, max_series, max_images)
-        typer.echo(f"Seeded {n} instances from '{collection}'")
+        seeder = new_seeder(repo, locations=loc_list, locale=locale)
+
+        if interval > 0:
+            scheduler = SeedScheduler(seeder, collection, interval, max_series, max_images, modality)
+            scheduler.start()
+            typer.echo(f"Scheduler running — seeding every {interval}m ({modality}). Press Ctrl+C to stop.")
+
+            stop_event = scheduler._stop
+            try:
+                signal.signal(signal.SIGTERM, lambda *_: stop_event.set())
+                stop_event.wait()
+            except KeyboardInterrupt:
+                pass
+            finally:
+                scheduler.stop()
+                scheduler.join(timeout=5)
+        else:
+            n = seeder.seed(collection, max_series, max_images, modality)
+            typer.echo(f"Seeded {n} instances from '{collection}' ({modality})")
     finally:
         repo.stop()

--- a/src/commands/serve.py
+++ b/src/commands/serve.py
@@ -1,10 +1,13 @@
+import logging
+import sys
+
 import typer
 from dicomhawk.app import new_dicomhawk
 from dicomhawk.handlers import new_dimse_factory
 from dicomhawk.middlewares import Middleware, new_honeytoken_injector
 from dicomhawk.repository import new_repo
 from dicomhawk.server import new_config, new_server
-from dicomhawk.bus import new_bus, new_dev_log
+from dicomhawk.bus import new_bus, new_dev_log, LevelColorFormatter
 from dicomhawk.storage import new_store
 
 serve_app = typer.Typer(help="dicomhawk runner")
@@ -80,6 +83,12 @@ def serve(
             "--dev-log",
             help="Path to the developer/internal log file (Python warnings and errors)"
         ),
+        verbose: bool = typer.Option(
+            False,
+            "--verbose",
+            "-v",
+            help="Print a compact colored event summary to stdout (auto-enabled when stdout is a TTY)"
+        ),
     ):
 
     p_int = [int(p) for p in ports.split(",")]
@@ -92,14 +101,24 @@ def serve(
     )
 
     store = new_store(traces)
-    
+
     injector = new_honeytoken_injector(honey_url, canary_pdf)
     mws: list[Middleware] = [injector]
-    
+
     repo = new_repo(database, store, mws)
-    bus = new_bus(log_path)
+    bus = new_bus(log_path, verbose=verbose)
     if dev_log_path:
         new_dev_log(dev_log_path)
+    else:
+        # No dev-log file: log to stdout so `docker logs` shows startup and errors.
+        fmt, datefmt = "%(asctime)s %(levelname)s %(name)s: %(message)s", "%Y-%m-%dT%H:%M:%S"
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(
+            LevelColorFormatter(fmt, datefmt) if sys.stdout.isatty()
+            else logging.Formatter(fmt, datefmt)
+        )
+        logging.basicConfig(level=logging.INFO, handlers=[handler])
+        logging.getLogger("pynetdicom").setLevel(logging.WARNING)
 
     dimse_fact = new_dimse_factory(repo, bus)
 

--- a/src/dicomhawk/bus.py
+++ b/src/dicomhawk/bus.py
@@ -1,16 +1,17 @@
 import hashlib
 import logging
+import sys
 import weakref
-import ujson
 
 from datetime import datetime, timezone
 from logging import Logger
 from logging.handlers import TimedRotatingFileHandler, RotatingFileHandler
 from pathlib import Path
-from typing import Optional
 
-from pynetdicom.events import Event
+import ujson
+
 from pydicom.dataset import Dataset
+from pynetdicom.events import Event
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,7 @@ class InteractionEvent:
         self.version = cache.get_version(assoc)
         self.ip = assoc.requestor.address
         self.port = assoc.requestor.port
+        self.local_port = assoc.acceptor.port
         self.timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
     def __str__(self) -> str:
@@ -134,48 +136,138 @@ class InteractionEvent:
             "version": self.version,
             "ip": self.ip,
             "port": self.port,
+            "local_port": self.local_port,
             "matches": self.matches,
             "timestamp": self.timestamp,
         })
 
 
-def _add_file_handler(
-    lg: Logger,
-    stdout: str,
-    when: Optional[str],
-    interval: int,
-    size: Optional[int],
-) -> None:
-    Path(stdout).parent.mkdir(parents=True, exist_ok=True)
-    if when:
-        h = TimedRotatingFileHandler(stdout, when=when, interval=interval)
-    elif size:
-        h = RotatingFileHandler(stdout, maxBytes=size)
-    else:
-        h = logging.FileHandler(stdout)
-    lg.addHandler(h)
+_LEVEL_COLORS: dict[str, str] = {
+    "INFO":    "\033[92m",  # green
+    "WARNING": "\033[93m",  # yellow
+    "ERROR":   "\033[91m",  # red
+}
+_RESET = "\033[0m"
+_DIM   = "\033[2m"
+
+
+class _ConsoleFormatter(logging.Formatter):
+    """One-liner per event for the terminal; reads InteractionEvent directly, no JSON round-trip."""
+
+    def __init__(self, use_color: bool) -> None:
+        super().__init__()
+        self._color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        ie = record.msg if isinstance(record.msg, InteractionEvent) else None
+        if ie is None:
+            msg = record.getMessage()
+            if self._color and record.levelno >= logging.WARNING:
+                c = _LEVEL_COLORS.get(record.levelname, "")
+                return f"{c}{record.levelname}{_RESET}  {msg}"
+            return f"{record.levelname}  {msg}"
+
+        c     = _LEVEL_COLORS.get(ie.log_level, "") if self._color else ""
+        reset = _RESET if self._color else ""
+        dim   = _DIM   if self._color else ""
+
+        ts    = ie.timestamp[11:19]  # HH:MM:SS from ISO string
+        parts = [
+            f"{dim}{ts}{reset}",
+            f"{ie.ip}:{ie.port}",
+            f":{ie.local_port}",
+            f"{c}{ie.request_type:<22}{reset}",
+        ]
+        if ie.query_level:
+            parts.append(ie.query_level)
+        if ie.matches is not None:
+            parts.append(f"matches={ie.matches}")
+        if ie.session_parameters:
+            parts.append(ie.session_parameters[0][:60])
+        if ie.version:
+            parts.append(f"{dim}[{ie.version}]{reset}")
+        return "  ".join(parts)
+
+
+class LevelColorFormatter(logging.Formatter):
+    """Colors the whole record by level (green/yellow/red) for terminal output."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        line = super().format(record)
+        c = _LEVEL_COLORS.get(record.levelname)
+        return f"{c}{line}{_RESET}" if c else line
 
 
 def new_bus(
-    stdout: Optional[str] = None,
-    when: Optional[str] = None,
+    stdout: str | None = None,
+    when: str | None = None,
     interval: int = 1,
-    size: Optional[int] = None,
+    size: int | None = None,
+    verbose: bool = False,
 ) -> Logger:
     lg = logging.getLogger("bus")
     lg.setLevel(logging.INFO)
     lg.propagate = False  # prevent JSON lines leaking into the root/dev logger
     if stdout:
-        _add_file_handler(lg, stdout, when, interval, size)
+        lg.addHandler(_build_handler(stdout, when, interval, size))
+    if verbose or sys.stdout.isatty():
+        h = logging.StreamHandler(sys.stdout)
+        h.setFormatter(_ConsoleFormatter(use_color=sys.stdout.isatty()))
+        lg.addHandler(h)
     return lg
+
+
+class _InnerFrameFormatter(logging.Formatter):
+    """Prepends '[in module]' from the innermost traceback frame, not the caller."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+        if record.exc_info:
+            tb = record.exc_info[2]
+            if tb:
+                while tb.tb_next:
+                    tb = tb.tb_next
+                module = tb.tb_frame.f_globals.get("__name__", "?")
+                base = f"[in {module}] {base}"
+        return base
 
 
 def new_dev_log(
     stdout: str,
-    when: Optional[str] = None,
+    when: str | None = None,
     interval: int = 1,
-    size: Optional[int] = None,
+    size: int | None = None,
 ) -> None:
+    fmt = _InnerFrameFormatter(
+        fmt="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
     root = logging.getLogger()
     root.setLevel(logging.WARNING)
-    _add_file_handler(root, stdout, when, interval, size)
+    h = _build_handler(stdout, when, interval, size)
+    h.setFormatter(fmt)
+    root.addHandler(h)
+
+    # Attach pynetdicom's own logger at INFO to the same file so association
+    # negotiation detail is available without the full DEBUG PDU dump.
+    pn = logging.getLogger("pynetdicom")
+    pn.setLevel(logging.INFO)
+    pn.propagate = False  # keep pynetdicom INFO out of the root WARNING stream
+    h2 = _build_handler(stdout, when, interval, size)
+    h2.setFormatter(fmt)
+    pn.addHandler(h2)
+
+
+def _build_handler(
+    stdout: str,
+    when: str | None,
+    interval: int,
+    size: int | None,
+) -> logging.Handler:
+    Path(stdout).parent.mkdir(parents=True, exist_ok=True)
+    if when:
+        return TimedRotatingFileHandler(stdout, when=when, interval=interval)
+    if size:
+        return RotatingFileHandler(stdout, maxBytes=size)
+    return logging.FileHandler(stdout)

--- a/src/dicomhawk/handlers.py
+++ b/src/dicomhawk/handlers.py
@@ -1,8 +1,10 @@
+import copy
 import logging
 from logging import Logger
-from typing import Callable, Any, Generator, Optional
+from typing import Callable, Any, Generator
 
 from pynetdicom import evt
+from pynetdicom.apps.qrscp import db as _qrdb
 from pynetdicom.pdu_primitives import A_ASSOCIATE, ImplementationVersionNameNotification
 from pydicom.dataset import Dataset
 from pynetdicom.events import Event, EventHandlerType, EventType
@@ -22,7 +24,13 @@ type EventHandler = Callable[
     ],
     Any,
 ]
-type QRResult = Generator[tuple[int, Optional[Dataset]], None, None]
+type QRResult = Generator[tuple[int, Dataset | None], None, None]
+
+# NOTE: private pynetdicom internals — AttributeError guard degrades to no-op rather than crash.
+try:
+    _QR_MODEL_ATTRS: dict = {**_qrdb._PATIENT_ROOT, **_qrdb._STUDY_ROOT}
+except AttributeError:
+    _QR_MODEL_ATTRS: dict = {}
 
 _QR_EVENTS: frozenset[EventType] = frozenset({
     evt.EVT_C_FIND,
@@ -35,6 +43,27 @@ _ACSE_EVENTS: frozenset[EventType] = frozenset({
     evt.EVT_RELEASED,
     evt.EVT_ABORTED,
 })
+
+
+def _strip_sublevel_tags(ds: Dataset, model) -> tuple[Dataset, list[str]]:
+    """Remove tags belonging to levels below QueryRetrieveLevel; return (filtered_ds, stripped)."""
+    attr = _QR_MODEL_ATTRS.get(model)
+    if attr is None:
+        return ds, []
+    ql = getattr(ds, "QueryRetrieveLevel", None)
+    if ql not in attr:
+        return ds, []
+    levels = list(attr.keys())
+    sublevel_tags: frozenset[str] = frozenset(
+        kw for lvl in levels[levels.index(ql) + 1:] for kw in attr[lvl]
+    )
+    stripped = [kw for kw in sublevel_tags if kw in ds]
+    if not stripped:
+        return ds, []
+    filtered = copy.deepcopy(ds)
+    for kw in stripped:
+        delattr(filtered, kw)
+    return filtered, stripped
 
 
 # --- ACSE handlers (plain functions, no yield) ---
@@ -79,10 +108,12 @@ def handle_find(repo: Repository, bus: Logger, cache: SessionCache, event: Event
         yield (err.status, None)
         return
 
-    idt = event.identifier
     model = event.request.AffectedSOPClassUID
+    idt, stripped = _strip_sublevel_tags(event.identifier, model)
     ql = _query_level(idt)
     params = _extract_params(idt)
+    if stripped:
+        params = (params or []) + [f"Stripped: {', '.join(stripped)}"]
 
     result = repo.find(idt, model, inject=True)
     if (err := result.error) is not None:
@@ -108,16 +139,12 @@ def handle_get(repo: Repository, bus: Logger, cache: SessionCache, event: Event)
         yield (err.status, None)
         return
 
-    try:
-        idt = event.identifier
-    except AttributeError as e:
-        bus.error(InteractionEvent(event, cache, "C-GET", session_parameters=[f"Error: {e}"], log_level="ERROR"))
-        yield (QRStatus.FAILURE, None)
-        return
-
     model = event.request.AffectedSOPClassUID
+    idt, stripped = _strip_sublevel_tags(event.identifier, model)
     ql = _query_level(idt)
     params = _extract_params(idt)
+    if stripped:
+        params = (params or []) + [f"Stripped: {', '.join(stripped)}"]
 
     result = repo.find(idt, model)
     if (err := result.error) is not None:
@@ -137,9 +164,10 @@ def handle_get(repo: Repository, bus: Logger, cache: SessionCache, event: Event)
         if (err := res.error) is not None:
             bus.error(InteractionEvent(event, cache, "C-GET", session_parameters=[err.error], log_level="ERROR"))
             yield (err.status, None)
+            continue
         yield (QRStatus.PENDING, res.dataset)
-
-    yield (QRStatus.SUCCESS, None)
+        # No trailing (SUCCESS, None): C-GET is count-based — it completes when the yielded
+        # sub-operations match the count, and an extra yield only logs a warning.
 
 
 def handle_move(repo: Repository, bus: Logger, cache: SessionCache, event: Event) -> QRResult:
@@ -149,19 +177,14 @@ def handle_move(repo: Repository, bus: Logger, cache: SessionCache, event: Event
         return
 
     destination = str(event.move_destination).strip()
-    ql = _query_level(event.identifier)
+    model = event.request.AffectedSOPClassUID
+    idt, stripped = _strip_sublevel_tags(event.identifier, model)
+    ql = _query_level(idt)
+    params: list[str] = [f"Destination: {destination}"]
+    if stripped:
+        params.append(f"Stripped: {', '.join(stripped)}")
 
-    # TODO: need destinations
-    # try:
-    #     addr, port = destinations[event.move_destination]
-    # except KeyError:
-    #     logger.info("No matching move destination in the configuration")
-    #     yield None, None
-    #     return
-    # contexts = list(set([ii.context for ii in matches]))
-    # yield addr, port, {"contexts": contexts[:128]}
-
-    bus.warning(InteractionEvent(event, cache, "C-MOVE", query_level=ql, session_parameters=[f"Destination: {destination}"], log_level="WARNING"))
+    bus.warning(InteractionEvent(event, cache, "C-MOVE", query_level=ql, session_parameters=params, log_level="WARNING"))
     yield (None, None)
 
 
@@ -195,28 +218,23 @@ def handle_store(repo: Repository, bus: Logger, cache: SessionCache, event: Even
     yield (QRStatus.SUCCESS, None)
 
 
+# The binders below adapt our (repo, bus, cache, event) handlers to pynetdicom's
+# (event, *args) callback signature, splitting on how pynetdicom consumes the result:
+# ACSE callbacks return nothing, QR callbacks are generators, simple DIMSE return a status int.
+
 def bind_acse(handler: EventHandler, repo: Repository, bus: Logger, cache: SessionCache) -> Callable:
-    # NOTE: if this binder grows with weird functionality before passing
-    # the event to the handler, we may want to have a pre-handler,
-    # middlewares, and post-handler effects?
     def binder(event: Event, *args):
         handler(repo, bus, cache, event, *args)
     return binder
 
 
 def bind_dimse_qr(handler: EventHandler, repo: Repository, bus: Logger, cache: SessionCache) -> Callable:
-    # NOTE: if this binder grows with weird functionality before passing
-    # the event to the handler, we may want to have a pre-handler,
-    # middlewares, and post-handler effects?
     def binder(event: Event, *args):
         yield from handler(repo, bus, cache, event, *args)
     return binder
 
 
 def bind_dimse_simple(handler: EventHandler, repo: Repository, bus: Logger, cache: SessionCache) -> Callable:
-    # NOTE: if this binder grows with weird functionality before passing
-    # the event to the handler, we may want to have a pre-handler,
-    # middlewares, and post-handler effects?
     def binder(event: Event, *args):
         gen = handler(repo, bus, cache, event, *args)
         try:
@@ -239,24 +257,10 @@ _handlers: list[tuple[str, EventType, EventHandler]] = [
 ]
 
 
-class DIMSEFactory:
-
-    def __init__(self) -> None:
-        self.handlers: dict[str, EventHandlerType] = {}
-        self.cache: SessionCache = SessionCache()
-
-    def get(self, name: str) -> EventHandlerType | None:
-        if handler := self.handlers.get(name):
-            return handler
-
-    def register(self, name: str, handler: EventHandlerType) -> 'DIMSEFactory':
-        self.handlers[name] = handler
-        return self
-
-
-def new_dimse_factory(repo: Repository, bus: Logger) -> DIMSEFactory:
-    factory = DIMSEFactory()
-    cache = factory.cache
+def new_dimse_factory(repo: Repository, bus: Logger) -> dict[str, EventHandlerType]:
+    """Map handler name -> (event type, pynetdicom callback). One SessionCache shared by all."""
+    cache = SessionCache()
+    handlers: dict[str, EventHandlerType] = {}
     for n, t, h in _handlers:
         if t in _ACSE_EVENTS:
             binder = bind_acse(h, repo, bus, cache)
@@ -264,5 +268,5 @@ def new_dimse_factory(repo: Repository, bus: Logger) -> DIMSEFactory:
             binder = bind_dimse_qr(h, repo, bus, cache)
         else:
             binder = bind_dimse_simple(h, repo, bus, cache)
-        factory.register(n, (t, binder))
-    return factory
+        handlers[n] = (t, binder)
+    return handlers

--- a/src/dicomhawk/repository.py
+++ b/src/dicomhawk/repository.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from pydicom import dcmread
 from pydicom.uid import UID
 from pydicom.dataset import Dataset
-from pydicom.pixel_data_handlers.util import apply_modality_lut
 
 from pynetdicom.events import Event
 from pynetdicom.apps.qrscp import db
@@ -103,12 +102,20 @@ class Repository:
         if not self.supports(sop:=event.request.AffectedSOPClassUID):
             return QRError(f"SOP Class not supported: {sop}", QRStatus.SOP_CLASS_NOT_SUPPORTED)
 
-        ds = event.identifier
+        try:
+            ds = event.identifier
+        except Exception as exc:
+            return QRError(f"Undecodable query identifier: {exc}", QRStatus.SOP_CLASS_INVALID)
         if not ds.get("QueryRetrieveLevel"):
             return QRError(f"request identifier not supported: {ds}", QRStatus.SOP_CLASS_INVALID)
         return None
     
     def find(self, ds: Dataset, model, inject: bool = False) -> QRResult:
+        # Zero-length keys = Universal Matching (PS3.4 C.2.2.2.3), but decode to "" which
+        # db.search single-value-matches → 0 results. Null them so empty queries match all.
+        for elem in ds:
+            if elem.keyword != "QueryRetrieveLevel" and elem.value is not None and str(elem.value) == "":
+                elem.value = None
         conn = self.conn
         try:
             matches = db.search(model, ds, conn)
@@ -128,14 +135,20 @@ class Repository:
         return QRResult(matches=matches)
 
     def store(self, ds: Dataset, safe: bool = False) -> QRError | None:
-        # NOTE: anything not safe is zipped and quarantined
-        # save a raw copy of the dataset with the current timestamp
+        # NOTE: anything not safe is zipped and quarantined — capture the raw
+        # attacker payload for forensics even if the rest of the store fails.
         if not safe:
-            with self.storage.temp() as tf:
-                ds.save_as(tf, enforce_file_format=False)
-                self.storage.compress(tf)
+            try:
+                with self.storage.temp() as tf:
+                    ds.save_as(tf, enforce_file_format=False)
+                    self.storage.compress(tf)
+            except Exception as exc:
+                logger.warning(f"Failed to quarantine C-STORE payload: {exc}")
 
-        fname = str(ds.SOPInstanceUID)
+        try:
+            fname = str(ds.SOPInstanceUID)
+        except AttributeError:
+            return QRError("C-STORE dataset missing SOPInstanceUID", QRStatus.STORE_ERROR)
 
         try:
             fpath = self.storage.path_for(safe, fname)
@@ -151,6 +164,13 @@ class Repository:
         except Exception as exc:
             return QRError(f"Failed writing instance to storage directory: {exc}", QRStatus.STORE_ERROR)
         
+        # add_instance raises KeyError if these identity keys are missing (common in attacker
+        # uploads); skip indexing — the raw payload is already quarantined.
+        missing = [kw for kw in ("PatientID", "StudyInstanceUID", "SeriesInstanceUID") if kw not in ds]
+        if missing:
+            logger.warning(f"Not indexing C-STORE dataset missing required keys: {', '.join(missing)}")
+            return None
+
         try:
             # Path is relative to the database file
             matches = (
@@ -179,10 +199,14 @@ class Repository:
         except Exception as exc:
             return FindResult(error=QRError(f"Error reading file: {match.filename}\n{exc}", QRStatus.READ_ERROR))
 
-        # NOTE: not sure this is needed tbh, why not sending files compressed?
         if decompress and instance.file_meta.TransferSyntaxUID.is_compressed:
-            instance.decompress()
-            apply_modality_lut(instance.pixel_array, instance)
+            try:
+                instance.decompress()
+            except Exception as exc:
+                return FindResult(error=QRError(
+                    f"Failed to decompress instance: {match.filename}\n{exc}",
+                    QRStatus.READ_ERROR,
+                ))
 
         if inject:
             instance = self._apply_middlewares(instance)

--- a/src/dicomhawk/seeder.py
+++ b/src/dicomhawk/seeder.py
@@ -1,10 +1,15 @@
 import io
+import json
 import logging
 import random
+import threading
 from dataclasses import dataclass
+from datetime import date, datetime, timedelta
 from hashlib import md5
+from pathlib import Path
 
 import requests
+from faker import Faker
 from pydicom import dcmread
 from pydicom.dataset import Dataset
 
@@ -13,75 +18,43 @@ from .repository import Repository
 logger = logging.getLogger(__name__)
 
 _NBIA_BASE = "https://services.cancerimagingarchive.net/nbia-api/services/v1"
+# Primary, then a mirror to fall back on when the primary is down or 406s.
+_OVERPASS_MIRRORS = (
+    "https://overpass-api.de/api/interpreter",
+    "https://overpass.kumi.systems/api/interpreter",
+)
+_OSM_CACHE_TTL_HOURS = 24
+_OSM_SKIP_TERMS = frozenset({
+    # English
+    "pharmacy", "dentist", "veterinary", "optician", "dispensary",
+    # Danish/Nordic
+    "apotek", "tandlæge", "dyrlæge",
+    # German
+    "apotheke", "zahnarzt", "tierarzt",
+    # French
+    "pharmacie", "dentiste", "vétérinaire",
+    # Spanish
+    "farmacia", "dentista", "veterinario",
+})
+_OSM_DEFAULT_MAX = 50
 
 
 @dataclass(frozen=True)
 class Location:
     institution: str
     address: str
-    physicians: tuple[str, ...]
-    patients: tuple[str, ...]
 
 
-_LOCATIONS: list[Location] = [
-    Location(
-        "Valley Medical Center",
-        "1400 West Valley Pkwy, Escondido, CA 92029",
-        ("Rivera^Carlos^M", "Patel^Anita^K", "Thompson^David^R"),
-        (
-            "Anderson^James^T", "Brown^Patricia^L", "Clark^Michael^S",
-            "Davis^Linda^J", "Evans^Robert^W", "Foster^Barbara^A",
-        ),
-    ),
-    Location(
-        "Riverside General Hospital",
-        "9851 Magnolia Ave, Riverside, CA 92503",
-        ("Nguyen^Thuy^H", "Kim^James^Y", "Okonkwo^Emeka^C"),
-        (
-            "Garcia^Maria^E", "Harris^Charles^B", "Jackson^Dorothy^M",
-            "Johnson^William^F", "Lewis^Ruth^A", "Martin^Joseph^D",
-        ),
-    ),
-    Location(
-        "Lakewood Community Hospital",
-        "3700 E South St, Lakewood, CA 90712",
-        ("Chen^Wei^L", "Sharma^Priya^N", "Robinson^Mark^A"),
-        (
-            "Moore^Thomas^H", "Nelson^Sandra^K", "Parker^Kevin^R",
-            "Roberts^Karen^S", "Scott^George^E", "Turner^Nancy^C",
-        ),
-    ),
-    Location(
-        "Northgate Regional Medical",
-        "5555 N Gate Blvd, Sacramento, CA 95834",
-        ("Williams^Janet^M", "Jones^Brian^T", "Martinez^Elena^R"),
-        (
-            "Walker^Steven^L", "White^Deborah^J", "Young^Edward^P",
-            "Adams^Carol^W", "Baker^Frank^N", "Campbell^Shirley^B",
-        ),
-    ),
-    Location(
-        "Desert Springs Medical Center",
-        "2075 E Flamingo Rd, Las Vegas, NV 89119",
-        ("Taylor^Michael^D", "Wilson^Sarah^A", "Lee^Kevin^J"),
-        (
-            "Collins^Harold^K", "Edwards^Gloria^T", "Flores^Miguel^A",
-            "Green^Helen^R", "Hall^Dennis^S", "Hill^Margaret^L",
-        ),
-    ),
-    Location(
-        "Summit View Hospital",
-        "800 Summit Ridge Dr, Denver, CO 80203",
-        ("Patel^Raj^S", "O'Brien^Katherine^M", "Yamamoto^Kenji^T"),
-        (
-            "Jenkins^Arthur^G", "King^Virginia^L", "Lee^Raymond^C",
-            "Mitchell^Donna^H", "Perry^Billy^J", "Reed^Alice^F",
-        ),
-    ),
+_DEFAULT_LOCATIONS: list[Location] = [
+    Location("Valley Medical Center", "1400 West Valley Pkwy, Escondido, CA 92029"),
+    Location("Riverside General Hospital", "9851 Magnolia Ave, Riverside, CA 92503"),
+    Location("Lakewood Community Hospital", "3700 E South St, Lakewood, CA 90712"),
+    Location("Northgate Regional Medical", "5555 N Gate Blvd, Sacramento, CA 95834"),
+    Location("Desert Springs Medical Center", "2075 E Flamingo Rd, Las Vegas, NV 89119"),
+    Location("Summit View Hospital", "800 Summit Ridge Dr, Denver, CO 80203"),
 ]
 
 _SENSITIVITY_TAGS = (
-    "PatientBirthDate",
     "PatientAddress",
     "PatientTelephoneNumbers",
     "OtherPatientIDs",
@@ -96,16 +69,221 @@ def _stable_pick(pool: tuple[str, ...], key: str) -> str:
     return pool[idx]
 
 
-def _patch_location(ds: Dataset, loc: Location) -> Dataset:
+def load_locations(path: str | None) -> list[Location]:
+    """Load locations from a JSON file, or return built-in defaults if path is None."""
+    if path is None:
+        return _DEFAULT_LOCATIONS
+    try:
+        data = json.loads(Path(path).read_text())
+        locs = [Location(e["institution"], e.get("address", "")) for e in data]
+        if not locs:
+            raise ValueError("empty locations file")
+        return locs
+    except Exception as exc:
+        logger.warning(f"Failed to load locations from '{path}': {exc}; using built-in defaults")
+        return _DEFAULT_LOCATIONS
+
+
+class OsmClient:
+    """Queries the Overpass API for hospital names and addresses in a given area."""
+
+    def __init__(
+        self,
+        city: str | None = None,
+        country: str | None = None,
+        cache_path: str | None = None,
+        timeout: int = 30,
+        max_results: int = _OSM_DEFAULT_MAX,
+    ):
+        self._city = city
+        self._country = country
+        self._cache = (
+            Path(cache_path)
+            if cache_path
+            else Path.home() / ".cache" / "dicomhawk" / "osm.json"
+        )
+        self._timeout = timeout
+        self._max_results = max_results
+
+    def get_locations(self) -> list[Location]:
+        """Return locations from cache if fresh, otherwise fetch from Overpass."""
+        if self._is_cache_valid():
+            cached = self._load_cache()
+            if cached:
+                logger.debug(f"OSM: loaded {len(cached)} locations from cache")
+                return cached
+
+        locs = self._fetch()
+        if locs:
+            self._save_cache(locs)
+            logger.info(f"OSM: fetched {len(locs)} medical institutions")
+        else:
+            logger.warning("OSM: no institutions found; falling back to built-in defaults")
+        return locs
+
+    def _fetch(self) -> list[Location]:
+        query = self._build_query()
+        # Explicit Accept avoids the primary's HTTP 406 (it's a header check, not the query).
+        headers = {
+            "User-Agent": "DICOMHawk/1.0 (https://github.com/honeynet/DICOMHawk)",
+            "Accept": "application/json",
+        }
+
+        for url in _OVERPASS_MIRRORS:
+            try:
+                r = requests.post(url, data={"data": query}, timeout=self._timeout, headers=headers)
+                r.raise_for_status()
+                body = r.json()
+                elements = body.get("elements", [])
+                # Overpass reports timeouts as HTTP 200 + empty result + a remark.
+                if not elements and "remark" in body:
+                    raise ValueError(body["remark"])
+                break
+            except (requests.RequestException, ValueError) as exc:
+                logger.warning(f"OSM Overpass query failed via {url}: {exc}")
+        else:
+            logger.error("OSM Overpass query failed on all mirrors")
+            return []
+
+        locs: list[Location] = []
+        seen: set[str] = set()
+        for el in elements:
+            tags = el.get("tags", {})
+            name = self._extract_name(tags)
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            locs.append(Location(name, self._extract_address(tags)))
+            if len(locs) >= self._max_results:
+                break
+        return locs
+
+    def _build_query(self) -> str:
+        # map_to_area pivot, not area∩area (which silently returns nothing for FR/US).
+        if self._city and self._country:
+            area = (
+                f'area["ISO3166-1:alpha2"="{self._country}"]["admin_level"="2"]->.country;\n'
+                f'rel(area.country)["name"="{self._city}"]["boundary"="administrative"]'
+                f'["admin_level"~"^[4-8]$"]->.c;\n'
+                f'.c map_to_area->.a;'
+            )
+        elif self._city:
+            area = (
+                f'rel["name"="{self._city}"]["boundary"="administrative"]'
+                f'["admin_level"~"^[4-8]$"]->.c;\n'
+                f'.c map_to_area->.a;'
+            )
+        elif self._country:
+            area = f'area["ISO3166-1:alpha2"="{self._country}"]["admin_level"="2"]->.a;'
+        else:
+            area = ""
+        scope = "(area.a)" if area else ""
+
+        return (
+            f'[out:json][timeout:{self._timeout}];\n'
+            f'{area}\n'
+            f'(\n'
+            f'  node["amenity"="hospital"]{scope};\n'
+            f'  way["amenity"="hospital"]{scope};\n'
+            f'  node["healthcare"="hospital"]{scope};\n'
+            f'  way["healthcare"="hospital"]{scope};\n'
+            f');\n'
+            f'out tags;'
+        )
+
+    def _extract_name(self, tags: dict) -> str | None:
+        # Verbatim (.title() mangles acronyms); 64 = VR LO limit, longer truncates on write.
+        for key in ("official_name", "name", "name:en", "alt_name", "brand"):
+            val = tags.get(key, "").strip()
+            if val and 3 <= len(val) <= 64:
+                if not any(t in val.lower() for t in _OSM_SKIP_TERMS):
+                    return val
+        return None
+
+    def _extract_address(self, tags: dict) -> str:
+        parts = [
+            tags.get("addr:housenumber", ""),
+            tags.get("addr:street", ""),
+            tags.get("addr:city", ""),
+            tags.get("addr:state", ""),
+            tags.get("addr:postcode", ""),
+        ]
+        return ", ".join(p for p in parts if p)
+
+    def _is_cache_valid(self) -> bool:
+        try:
+            data = json.loads(self._cache.read_text())
+            # Per-query cache: a different city/country is a miss, not a stale hit.
+            if data.get("city") != self._city or data.get("country") != self._country:
+                return False
+            ts = datetime.fromisoformat(data["timestamp"])
+            return datetime.now() < ts + timedelta(hours=_OSM_CACHE_TTL_HOURS)
+        except Exception:
+            return False
+
+    def _load_cache(self) -> list[Location]:
+        try:
+            data = json.loads(self._cache.read_text())
+            return [
+                Location(e["institution"], e.get("address", ""))
+                for e in data["locations"]
+            ]
+        except Exception:
+            return []
+
+    def _save_cache(self, locs: list[Location]) -> None:
+        try:
+            self._cache.parent.mkdir(parents=True, exist_ok=True)
+            self._cache.write_text(json.dumps({
+                "timestamp": datetime.now().isoformat(),
+                "city": self._city,
+                "country": self._country,
+                "locations": [
+                    {"institution": l.institution, "address": l.address} for l in locs
+                ],
+            }))
+        except Exception as exc:
+            logger.warning(f"OSM: failed to save cache: {exc}")
+
+
+_BIRTH_DATE_START = date(1955, 1, 1)
+_BIRTH_DATE_RANGE = (date(1999, 12, 31) - _BIRTH_DATE_START).days
+_STUDY_DATE_START = date(2010, 1, 1)
+_STUDY_DATE_RANGE = (date(2024, 12, 31) - _STUDY_DATE_START).days
+
+
+def _stable_date(start: date, day_range: int, key: str, salt: str) -> str:
+    """Deterministic YYYYMMDD date derived from a hash of key+salt."""
+    digest = int(md5(f"{key}{salt}".encode()).hexdigest(), 16)
+    return (start + timedelta(days=digest % day_range)).strftime("%Y%m%d")
+
+
+def _patch_location(
+    ds: Dataset,
+    loc: Location,
+    male_pool: tuple[str, ...],
+    female_pool: tuple[str, ...],
+    physician_pool: tuple[str, ...],
+) -> Dataset:
     patient_key = str(getattr(ds, "PatientID", "") or getattr(ds, "PatientName", "") or "")
     study_key = str(getattr(ds, "StudyInstanceUID", patient_key) or patient_key)
 
+    # Deterministic sex: odd hash byte → M, even → F
+    sex = "M" if int(md5(patient_key.encode()).hexdigest()[0], 16) % 2 else "F"
+    name_pool = male_pool if sex == "M" else female_pool
+
+    # UTF-8: OSM names (œ, curly quotes) and non-Latin --locale names exceed Latin-1.
+    ds.SpecificCharacterSet = "ISO_IR 192"
     ds.InstitutionName = loc.institution
     ds.InstitutionAddress = loc.address
     ds.StationName = f"{getattr(ds, 'Modality', 'XX')}01"
-    ds.PatientName = _stable_pick(loc.patients, patient_key)
+    ds.PatientName = _stable_pick(name_pool, patient_key)
     ds.PatientID = md5(patient_key.encode()).hexdigest()[:8].upper()
-    ds.ReferringPhysicianName = _stable_pick(loc.physicians, study_key)
+    ds.PatientSex = sex
+    ds.PatientBirthDate = _stable_date(_BIRTH_DATE_START, _BIRTH_DATE_RANGE, patient_key, "dob")
+    ds.StudyDate = _stable_date(_STUDY_DATE_START, _STUDY_DATE_RANGE, study_key, "std")
+    ds.SeriesDate = ds.StudyDate
+    ds.ReferringPhysicianName = _stable_pick(physician_pool, study_key)
 
     for tag in _SENSITIVITY_TAGS:
         if hasattr(ds, tag):
@@ -163,19 +341,78 @@ class TciaClient:
             return None
 
 
+class SeedScheduler(threading.Thread):
+    """Daemon thread that re-seeds the honeypot on a fixed interval."""
+
+    def __init__(
+        self,
+        seeder: "Seeder",
+        collection: str,
+        interval_minutes: int,
+        max_series: int = 3,
+        max_images: int = 5,
+        modality: str = "CT",
+    ):
+        super().__init__(daemon=True, name="dicomhawk-seeder")
+        self._seeder = seeder
+        self._collection = collection
+        self._interval = interval_minutes * 60
+        self._max_series = max_series
+        self._max_images = max_images
+        self._modality = modality
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        logger.info(
+            f"Seed scheduler started — interval: {self._interval // 60}m, "
+            f"collection: '{self._collection}', modality: '{self._modality}'"
+        )
+        while not self._stop.wait(self._interval):
+            n = self._seeder.seed(self._collection, self._max_series, self._max_images, self._modality)
+            logger.info(f"Scheduled seed completed: {n} instances stored")
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
 class Seeder:
-    def __init__(self, repo: Repository):
+    def __init__(
+        self,
+        repo: Repository,
+        locations: list[Location] | None = None,
+        locale: str = "en_US",
+    ):
         self._repo = repo
         self._client = TciaClient()
+        self._locations = locations if locations else _DEFAULT_LOCATIONS
+        faker = Faker(locale)
+        # "^" = DICOM PN separator (Family^Given). Split pools keep PatientSex consistent;
+        # first_name_male/female is absent for some locales, so fall back to name().
+        try:
+            self._male_pool: tuple[str, ...] = tuple(
+                f"{faker.last_name()}^{faker.first_name_male()}" for _ in range(100)
+            )
+            self._female_pool: tuple[str, ...] = tuple(
+                f"{faker.last_name()}^{faker.first_name_female()}" for _ in range(100)
+            )
+        except AttributeError:
+            names = tuple(faker.name() for _ in range(200))
+            self._male_pool = names[:100]
+            self._female_pool = names[100:]
+        self._physician_pool: tuple[str, ...] = tuple(
+            f"{faker.last_name()}^{faker.first_name()}" for _ in range(50)
+        )
 
-    def seed(self, collection: str, max_series: int = 3, max_images: int = 5) -> int:
-        loc = random.choice(_LOCATIONS)
-        series_list = self._client.get_series(collection)
+    def seed(self, collection: str, max_series: int = 3, max_images: int = 5, modality: str = "CT") -> int:
+        loc = random.choice(self._locations)
+        series_list = self._client.get_series(collection, modality)
         if not series_list:
-            logger.warning(f"TCIA unreachable or no CT series in '{collection}'; nothing seeded")
+            logger.warning(
+                f"TCIA unreachable or no {modality} series in '{collection}'; "
+                f"nothing seeded (re-run when TCIA is available, or use --interval to retry automatically)"
+            )
             return 0
 
-        # prefer smaller series to keep seeding fast
         series_list.sort(key=lambda s: int(s.get("NumberOfSeriesRelatedInstances", 999)))
 
         stored = 0
@@ -183,7 +420,7 @@ class Seeder:
             if uid := entry.get("SeriesInstanceUID"):
                 stored += self._ingest_series(uid, loc, max_images)
 
-        logger.info(f"Seeded {stored} instances from '{collection}' as '{loc.institution}'")
+        logger.info(f"Seeded {stored} instances from '{collection}' ({modality}) as '{loc.institution}'")
         return stored
 
     def _ingest_series(self, series_uid: str, loc: Location, max_images: int) -> int:
@@ -199,7 +436,7 @@ class Seeder:
             except Exception as exc:
                 logger.error(f"Error reading {sop_uid}: {exc}")
                 continue
-            ds = _patch_location(ds, loc)
+            ds = _patch_location(ds, loc, self._male_pool, self._female_pool, self._physician_pool)
             err = self._repo.store(ds, safe=True)
             if err is None:
                 stored += 1
@@ -209,5 +446,9 @@ class Seeder:
         return stored
 
 
-def new_seeder(repo: Repository) -> Seeder:
-    return Seeder(repo)
+def new_seeder(
+    repo: Repository,
+    locations: list[Location] | None = None,
+    locale: str = "en_US",
+) -> Seeder:
+    return Seeder(repo, locations=locations, locale=locale)

--- a/src/dicomhawk/server.py
+++ b/src/dicomhawk/server.py
@@ -1,27 +1,18 @@
 
 import logging
 from logging import Logger
-from copy import copy
 from dataclasses import dataclass
 from itertools import chain
-from pynetdicom import (
-    evt,
-    AE,
-)
+from pynetdicom import AE
 
 from pynetdicom.events import EventHandlerType
 from pynetdicom.transport import ThreadedAssociationServer
-from pynetdicom.presentation import (
-    AllStoragePresentationContexts,
-    StoragePresentationContexts,
-)
+from pynetdicom.presentation import AllStoragePresentationContexts
 
 from pynetdicom.sop_class import (
     _QR_CLASSES,
     _VERIFICATION_CLASSES
 )
-
-from .handlers import DIMSEFactory
 
 logger = logging.getLogger(__name__)
 
@@ -55,19 +46,6 @@ class Server:
         self.config = config
         self.handlers = handlers
 
-    def make_handlers(self, handlers: DIMSEFactory):
-        # TODO: the config should have a list of supported operations
-        return [
-            (evt.EVT_ACSE_RECV, handlers.get("associate")),
-            (evt.EVT_RELEASED, handlers.get("release")),
-            (evt.EVT_C_FIND, handlers.get("find")),
-            (evt.EVT_C_STORE, handlers.get("store")),
-            (evt.EVT_C_ECHO, handlers.get("echo")),
-            (evt.EVT_C_MOVE, handlers.get("move")),
-            (evt.EVT_C_GET, handlers.get("get")),
-            (evt.EVT_ABORTED, handlers.get("abort")),
-        ]
-
     def init(self) -> AE:
         logger.debug("Initializing AE")
 
@@ -84,19 +62,10 @@ class Server:
         # from greedy malware
         ae.maximum_pdu_size = 65536
 
-        # Set supported operations 
-        store_ctx = copy(StoragePresentationContexts)
-        for ctx in store_ctx:
-
-            # TODO: this could come from some sort of setting
-            # to decide what we are
-            ctx._as_scp = True
-            ctx._as_scu = True
-            ctx.scp_role = True
-            ctx.scu_role = True
-
-        ae.requested_contexts = store_ctx
-        ae.supported_contexts = AllStoragePresentationContexts
+        # scu_role lets the server SEND instances during C-GET/C-MOVE sub-operations; scp_role
+        # lets it RECEIVE C-STORE. Without scu_role, C-GET sub-operations are rejected.
+        for ctx in AllStoragePresentationContexts:
+            ae.add_supported_context(ctx.abstract_syntax, scu_role=True, scp_role=True)
 
         for qr in chain(_QR_CLASSES.values(), _VERIFICATION_CLASSES.values()):
             ae.add_supported_context(qr)

--- a/src/dicomhawk/storage.py
+++ b/src/dicomhawk/storage.py
@@ -23,38 +23,17 @@ class Storage:
         return str(self.quarantine_dir)
 
     def _jailed_path(self, root: Path, filename: str) -> Path:
-        """
-        Resolve a path within the jail directory.
-        
-        Validates that the resolved path remains within the jail boundary,
-        preventing path traversal attacks via crafted filenames.
-        
-        Args:
-            root: The jail root directory (storage_dir or quarantine_dir)
-            filename: The filename to validate
-            
-        Returns:
-            Path: The resolved path if valid
-            
-        Raises:
-            ValueError: If filename is absolute or would escape the jail,
-                       including the problematic filename and resolved path
-                       in the error message for debugging.
-        """
+        """Resolve filename under root, rejecting absolute paths and traversal escapes."""
         if Path(filename).is_absolute():
-            raise ValueError(
-                f"Absolute paths not allowed in jail. Got: {filename}"
-            )
-        
+            raise ValueError(f"Absolute paths not allowed in jail. Got: {filename}")
+
         root_resolved = root.resolve()
         full = (root / filename).resolve()
-        
         if not full.is_relative_to(root_resolved):
             raise ValueError(
                 f"Path traversal detected: filename '{filename}' resolved to "
                 f"'{full}' which escapes jail boundary '{root_resolved}'"
             )
-        
         return full
 
     def is_quarantined(self, path: str) -> bool:
@@ -66,22 +45,7 @@ class Storage:
             return False
 
     def path_for(self, safe: bool, filename: str) -> Path:
-        """
-        Get a jailed path for the given filename.
-        
-        Routes to either storage_dir (safe=True) or quarantine_dir (safe=False).
-        Validates that the path remains within the jail boundary.
-        
-        Args:
-            safe: If True, use storage_dir; if False, use quarantine_dir
-            filename: The filename to jail
-            
-        Returns:
-            Path: The validated jailed path
-            
-        Raises:
-            ValueError: If the filename would escape the jail
-        """
+        """Jailed path for filename under storage_dir (safe) or quarantine_dir."""
         root = self.storage_dir if safe else self.quarantine_dir
         return self._jailed_path(root, filename)
     


### PR DESCRIPTION
- OSM: map_to_area city lookup, mirror + Accept-header fallback
- Faker names as DICOM PN 
- C-FIND: empty keys now Universal-Match instead of returning nothing
- C-STORE: skip indexing datasets missing identity keys
- C-GET: storage contexts get scu_role so instances are actually returned

